### PR TITLE
move DynetScalaHelpers into own file (and build in make)

### DIFF
--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -56,3 +56,22 @@ add_jar(
     "${CMAKE_SWIG_OUTDIR}/Tensor.java"
     "${CMAKE_SWIG_OUTDIR}/Trainer.java"
 )
+
+# TODO(joelgrus): This is probably not defensive or robust enough.
+option(INCLUDE_SCALA_HELPERS "INCLUDE_SCALA_HELPERS" ON)
+if(INCLUDE_SCALA_HELPERS)
+  # Compile the scala helpers
+  add_custom_command(
+    COMMENT "Building scala helpers"
+    OUTPUT scala_helper_compiled
+    DEPENDS dynet_swigJNI
+    COMMAND scalac -classpath ${CMAKE_CURRENT_BINARY_DIR}/dynet_swigJNI.jar
+                   -d         ${CMAKE_CURRENT_BINARY_DIR}/dynet_scala_helpers.jar
+                              ${CMAKE_CURRENT_LIST_DIR}/DynetScalaHelpers.scala
+  )
+
+  add_custom_target(scala_helper ALL DEPENDS scala_helper_compiled)
+
+endif()
+
+

--- a/swig/DynetScalaHelpers.scala
+++ b/swig/DynetScalaHelpers.scala
@@ -1,0 +1,28 @@
+package edu.cmu.dynet
+
+import edu.cmu.dynet.dynet_swig._
+
+import scala.language.implicitConversions
+
+object DynetScalaHelpers {
+
+  def dim(dims: Int*): Dim = {
+    val dimInts = new LongVector
+    dims.foreach(dimInts.add)
+    new Dim(dimInts)
+  }
+
+  implicit class Untensor(t: Tensor) {
+    def toFloat: Float = as_scalar(t)
+    def toVector: FloatVector = as_vector(t)
+  }
+
+  implicit class RichExpression(e: Expression) {
+    def +(e2: Expression): Expression = exprPlus(e, e2)
+    def *(e2: Expression): Expression = exprTimes(e, e2)
+    def -(e2: Expression): Expression = exprMinus(e, e2)
+    def +(r: Float): Expression = exprPlus(e, r)
+    def *(r: Float): Expression = exprTimes(e, r)
+    def -(r: Float): Expression = exprMinus(e, r)
+  }
+}

--- a/swig/README.md
+++ b/swig/README.md
@@ -3,6 +3,11 @@
 The code in `dynet_swig.i` provides SWIG instructions to wrap salient parts of DyNet for use
 in other languages, in particular Java (and Scala).
 
+## Scala Helpers
+
+The code in `DynetScalaHelpers.scala` provides helper functions and implicit conversions that 
+facilitate using DyNet from Scala.
+
 ## Building
 
 To include in the DyNet build, add `-DINCLUDE_SWIG=ON` to the `cmake` command, e.g., run this from
@@ -13,14 +18,24 @@ build$ cmake .. -DEIGEN3_INCLUDE_DIR=../eigen -DINCLUDE_SWIG=ON
 build$ make
 ```
 
+By default, this will create one jar for the Dynet bindings and a second jar
+for the Scala helpers. If you don't want the Scala helpers (and, in particular, if you
+don't have the `scalac` compiler) then when you run `cmake` include the additional flag
+
+```
+-DINCLUDE_SCALA_HELPERS=OFF
+```
+
 If successful, the end of the build should look something like:
 
 ```
-[ 96%] Built target dynet_swig
-[ 97%] Building Java objects for dynet_swigJNI.jar
-[ 98%] Generating CMakeFiles/dynet_swigJNI.dir/java_class_filelist
-[100%] Creating Java archive dynet_swigJNI.jar
-[100%] Built target dynet_swigJNI
+[ 93%] Building Java objects for dynet_swigJNI.jar
+[ 94%] Generating CMakeFiles/dynet_swigJNI.dir/java_class_filelist
+[ 95%] Creating Java archive dynet_swigJNI.jar
+[ 95%] Built target dynet_swigJNI
+[ 96%] Building scala
+[ 96%] Built target scala_helper
+[100%] Built target dynet_swig
 ```
 
 and (in MacOS) you should have the library files `build/swig/libdynet_swig.jnilib` and
@@ -28,11 +43,12 @@ and (in MacOS) you should have the library files `build/swig/libdynet_swig.jnili
 
 ## Running the example
 
-Here's a simple way to run the Scala example in the `swig/examples` directory:
+After running `make`, you can run the Scala examples in the `swig/examples` directory like:
 
 ```
-example$ scalac -cp ../../build/swig/dynet_swigJNI.jar XorScala.scala
-example$ scala -cp .:../../build/swig/dynet_swigJNI.jar -Djava.library.path=../../build/swig XorScala
+example$ export DYNETJARS=../../build/swig/dynet_swigJNI.jar:../../build/swig/dynet_scala_helpers.jar
+example$ scalac -cp $DYNETJARS XorScala.scala
+example$ scala -cp .:$DYNETJARS -Djava.library.path=../../build/swig XorScala
 ```
 
 Similarly for the Java example (with output):

--- a/swig/examples/LinearRegression.scala
+++ b/swig/examples/LinearRegression.scala
@@ -23,10 +23,10 @@ object LinearRegression {
     val trainer = new SimpleSGDTrainer(model, 0.01f)
     val cg = new ComputationGraph
 
-    val p_W = model.add_parameters(Seq(1))
+    val p_W = model.add_parameters(dim(1))
     val W = parameter(cg, p_W)
 
-    val p_b = model.add_parameters(Seq(1))
+    val p_b = model.add_parameters(dim(1))
     val b = parameter(cg, p_b)
 
     for (iter <- 1 to 20) {
@@ -41,8 +41,8 @@ object LinearRegression {
       }
 
       // print the current parameter values
-      val W_ = as_scalar(p_W.values)
-      val b_ = as_scalar(p_b.values)
+      val W_ = p_W.values.toFloat
+      val b_ = p_b.values.toFloat
       println(s"(iter $iter) y = $W_ x + $b_ (error: $iterLoss)")
     }
   }

--- a/swig/examples/XorScala.scala
+++ b/swig/examples/XorScala.scala
@@ -1,26 +1,6 @@
 import edu.cmu.dynet._
 import edu.cmu.dynet.dynet_swig._
 
-import scala.language.implicitConversions
-
-// This will go in an associated shared library
-object DynetScalaHelpers {
-
-  implicit def makeDim(dims: Seq[Int]): Dim = {
-    val dimInts = new LongVector
-    dims.map(dimInts.add)
-    new Dim(dimInts)
-  }
-
-  implicit class RichExpression(e: Expression) {
-    def +(e2: Expression): Expression = exprPlus(e, e2)
-    def *(e2: Expression): Expression = exprTimes(e, e2)
-    def -(e2: Expression): Expression = exprMinus(e, e2)
-    def +(r: Float): Expression = exprPlus(e, r)
-    def *(r: Float): Expression = exprTimes(e, r)
-    def -(r: Float): Expression = exprMinus(e, r)  }
-}
-
 object XorScala {
   val HIDDEN_SIZE = 8
   val ITERATIONS = 30
@@ -35,10 +15,10 @@ object XorScala {
     val sgd = new SimpleSGDTrainer(m)
     val cg = new ComputationGraph
 
-    val p_W = m.add_parameters(Seq(HIDDEN_SIZE, 2))
-    val p_b = m.add_parameters(Seq(HIDDEN_SIZE))
-    val p_V = m.add_parameters(Seq(1, HIDDEN_SIZE))
-    val p_a = m.add_parameters(Seq(1))
+    val p_W = m.add_parameters(dim(HIDDEN_SIZE, 2))
+    val p_b = m.add_parameters(dim(HIDDEN_SIZE))
+    val p_V = m.add_parameters(dim(1, HIDDEN_SIZE))
+    val p_a = m.add_parameters(dim(1))
 
     val W = parameter(cg, p_W)
     val b = parameter(cg, p_b)
@@ -46,7 +26,7 @@ object XorScala {
     val a = parameter(cg, p_a)
 
     val x_values = new FloatVector(2)
-    val x = input(cg, Seq(2), x_values)
+    val x = input(cg, dim(2), x_values)
     var y_value = 0f
     val y = input(cg, y_value)
 


### PR DESCRIPTION
This is a baby step in the right direction:

* move DynetScalaHelpers into their own file
* replace implicit conversion Seq -> Dim with explicit `dim` function (same # of characters, clearer)
* add implicit `Untensor` class to get `.toFloat` and `.toVector` methods on dynet tensors
* add CMake rule to build `dynet_scala_helpers.jar`
* update README to account for new instructions

I have never really worked with cmake before, so I'm sure that part could be improved. Also, I'd rather produce one combined jar rather than two separate ones, but I think that will require adding sbt into the mix, so I'll do that in the future. Finally, I know we want to clean up the directory structure, that will also happen in the future.