### PR TITLE
create uberjar with scala helpers using sbt

### DIFF
--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -60,17 +60,27 @@ add_jar(
 # TODO(joelgrus): This is probably not defensive or robust enough.
 option(INCLUDE_SCALA_HELPERS "INCLUDE_SCALA_HELPERS" ON)
 if(INCLUDE_SCALA_HELPERS)
-  # Compile the scala helpers
+
+  # Make sure the lib directory exists
+  file(MAKE_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/lib)
+
+  # Copy the dynet_swig jar over there
+  file(COPY ${CMAKE_CURRENT_BINARY_DIR}/dynet_swigJNI.jar
+       DESTINATION ${CMAKE_CURRENT_LIST_DIR}/lib)
+
+  # Find sbt
+  find_program(SBT sbt)
+
+  # Run sbt assembly
   add_custom_command(
-    COMMENT "Building scala helpers"
-    OUTPUT scala_helper_compiled
+    COMMENT "Running sbt"
+    OUTPUT scala_helper_uberjar
     DEPENDS dynet_swigJNI
-    COMMAND scalac -classpath ${CMAKE_CURRENT_BINARY_DIR}/dynet_swigJNI.jar
-                   -d         ${CMAKE_CURRENT_BINARY_DIR}/dynet_scala_helpers.jar
-                              ${CMAKE_CURRENT_LIST_DIR}/src/main/scala/edu/cmu/dynet/DynetScalaHelpers.scala
+    COMMAND ${SBT} assembly
+    WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
   )
 
-  add_custom_target(scala_helper ALL DEPENDS scala_helper_compiled)
+  add_custom_target(scala_helper ALL DEPENDS scala_helper_uberjar)
 
 endif()
 

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -61,13 +61,6 @@ add_jar(
 option(INCLUDE_SCALA_HELPERS "INCLUDE_SCALA_HELPERS" ON)
 if(INCLUDE_SCALA_HELPERS)
 
-  # Make sure the lib directory exists
-  file(MAKE_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/lib)
-
-  # Copy the dynet_swig jar over there
-  file(COPY ${CMAKE_CURRENT_BINARY_DIR}/dynet_swigJNI.jar
-       DESTINATION ${CMAKE_CURRENT_LIST_DIR}/lib)
-
   # Find sbt
   find_program(SBT sbt)
 

--- a/swig/README.md
+++ b/swig/README.md
@@ -19,8 +19,8 @@ build$ make dynet_swig && make
 ```
 
 In MacOS, this will create the library files `dynet_swigJNI.jar` and `libdynet_swig.jnilib` in the `build/swig` directory. 
-It will then run `sbt assembly` in the `swig` directory to produce
-an "uberjar" containing both the Dynet bindings and the scala helpers under `swig/target`.
+It will then run `sbt assembly` to produce an "uberjar" containing 
+both the Dynet bindings and the scala helpers, also in `build/swig`.
 
 If you don't want the Scala helpers (and, in particular, if you
 don't have `sbt`) then when you run `cmake` include the additional flag

--- a/swig/README.md
+++ b/swig/README.md
@@ -5,7 +5,7 @@ in other languages, in particular Java (and Scala).
 
 ## Scala Helpers
 
-The code in `DynetScalaHelpers.scala` provides helper functions and implicit conversions that 
+The code in `src/main/scala` provides helper functions and implicit conversions that 
 facilitate using DyNet from Scala.
 
 ## Building
@@ -15,12 +15,15 @@ the `build` directory (see [DyNet documentation](http://dynet.readthedocs.io/en/
 
 ```
 build$ cmake .. -DEIGEN3_INCLUDE_DIR=../eigen -DINCLUDE_SWIG=ON
-build$ make
+build$ make dynet_swig && make
 ```
 
-By default, this will create one jar for the Dynet bindings and a second jar
-for the Scala helpers. If you don't want the Scala helpers (and, in particular, if you
-don't have the `scalac` compiler) then when you run `cmake` include the additional flag
+In MacOS, this will create the library files `dynet_swigJNI.jar` and `libdynet_swig.jnilib` in the `build/swig` directory. 
+By default, it will also copy the jar file into `swig/lib` and run `sbt assembly` in the `swig` directory to produce
+an "uberjar" containing both the Dynet bindings and the scala helpers under `swig/target`.
+
+If you don't want the Scala helpers (and, in particular, if you
+don't have `sbt`) then when you run `cmake` include the additional flag
 
 ```
 -DINCLUDE_SCALA_HELPERS=OFF
@@ -33,25 +36,25 @@ If successful, the end of the build should look something like:
 [ 94%] Generating CMakeFiles/dynet_swigJNI.dir/java_class_filelist
 [ 95%] Creating Java archive dynet_swigJNI.jar
 [ 95%] Built target dynet_swigJNI
-[ 96%] Building scala
+[ 96%] Running sbt
+...
+[info] lots of sbt stuff here
+...
+[success] Total time: 7 s, completed Jan 11, 2017 1:05:58 PM
 [ 96%] Built target scala_helper
 [100%] Built target dynet_swig
 ```
 
-and (in MacOS) you should have the library files `build/swig/libdynet_swig.jnilib` and
-`build/swig/dynet_swigJNI.jar`.
-
 ## Running the example
 
-After running `make`, you can run the Scala examples under the `swig` directory like:
+After running `make`, you can run the Scala examples under the `swig` directory with `sbt`:
 
 ```
-swig$ export DYNETJARS=../build/swig/dynet_swigJNI.jar:../build/swig/dynet_scala_helpers.jar
-swig$ scalac -cp $DYNETJARS src/main/scala/edu/cmu/dynet/examples/XorScala.scala
-swig$ scala -cp .:edu/cmu/dynet/examples:$DYNETJARS -Djava.library.path=../build/swig edu.cmu.dynet.examples.XorScala
+swig$ sbt "runMain edu.cmu.dynet.examples.XorScala"
+swig$ sbt "runMain edu.cmu.dynet.examples.LinearRegression"
 ```
 
-Similarly for the Java example (with output):
+The Java example takes a couple more steps:
 
 ```
 swig$ javac -d . -cp ../build/swig/dynet_swigJNI.jar src/main/java/edu/cmu/dynet/examples/XorExample.java

--- a/swig/README.md
+++ b/swig/README.md
@@ -19,7 +19,7 @@ build$ make dynet_swig && make
 ```
 
 In MacOS, this will create the library files `dynet_swigJNI.jar` and `libdynet_swig.jnilib` in the `build/swig` directory. 
-By default, it will also copy the jar file into `swig/lib` and run `sbt assembly` in the `swig` directory to produce
+It will then run `sbt assembly` in the `swig` directory to produce
 an "uberjar" containing both the Dynet bindings and the scala helpers under `swig/target`.
 
 If you don't want the Scala helpers (and, in particular, if you

--- a/swig/build.sbt
+++ b/swig/build.sbt
@@ -1,6 +1,9 @@
+
 name := "dynet_scala_helpers"
 
 scalaVersion := "2.11.8"
+
+unmanagedBase := file( "../build/swig" ).getAbsoluteFile
 
 assemblyJarName in assembly := "dynet_swigJNI_scala.jar"
 

--- a/swig/build.sbt
+++ b/swig/build.sbt
@@ -3,9 +3,19 @@ name := "dynet_scala_helpers"
 
 scalaVersion := "2.11.8"
 
-unmanagedBase := file( "../build/swig" ).getAbsoluteFile
+// This is where `make` does all its work, and it's where we'll do all our work as well.
+val buildPath = "../build/swig"
 
-assemblyJarName in assembly := "dynet_swigJNI_scala.jar"
+// Look for the dynet_swig jar file there.
+unmanagedBase := file( buildPath ).getAbsoluteFile
+
+// Put all of the sbt generated classes there.
+target := file(s"${buildPath}/target/")
+
+// Put the uberjar there.
+assemblyOutputPath in assembly := file(s"${buildPath}/dynet_swigJNI_scala.jar").getAbsoluteFile
 
 fork in run := true
-javaOptions in run += "-Djava.library.path=../build/swig"
+
+// And look there for java libraries when running.
+javaOptions in run += s"-Djava.library.path=${buildPath}"

--- a/swig/build.sbt
+++ b/swig/build.sbt
@@ -1,0 +1,8 @@
+name := "dynet_scala_helpers"
+
+scalaVersion := "2.11.8"
+
+assemblyJarName in assembly := "dynet_swigJNI_scala.jar"
+
+fork in run := true
+javaOptions in run += "-Djava.library.path=../build/swig"

--- a/swig/project/assembly.sbt
+++ b/swig/project/assembly.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")


### PR DESCRIPTION
replaces the `scalac` make step with `sbt`, configured to produce one jar with both the dynet bindings and the scala helpers (and with the examples too)
