### PR TITLE
pass in buildpath to sbt as a command line arg

### DIFF
--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -69,7 +69,7 @@ if(INCLUDE_SCALA_HELPERS)
     COMMENT "Running sbt"
     OUTPUT scala_helper_uberjar
     DEPENDS dynet_swigJNI
-    COMMAND ${SBT} assembly
+    COMMAND ${SBT} assembly -Dbuildpath=${CMAKE_CURRENT_BINARY_DIR}
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
   )
 

--- a/swig/README.md
+++ b/swig/README.md
@@ -50,8 +50,8 @@ If successful, the end of the build should look something like:
 After running `make`, you can run the Scala examples under the `swig` directory with `sbt`:
 
 ```
-swig$ sbt "runMain edu.cmu.dynet.examples.XorScala"
-swig$ sbt "runMain edu.cmu.dynet.examples.LinearRegression"
+swig$ sbt "runMain edu.cmu.dynet.examples.XorScala" -Dbuildpath=../build/swig
+swig$ sbt "runMain edu.cmu.dynet.examples.LinearRegression" -Dbuildpath=../build/swig
 ```
 
 The Java example takes a couple more steps:

--- a/swig/build.sbt
+++ b/swig/build.sbt
@@ -4,7 +4,10 @@ name := "dynet_scala_helpers"
 scalaVersion := "2.11.8"
 
 // This is where `make` does all its work, and it's where we'll do all our work as well.
-val buildPath = "../build/swig"
+val buildPath = sys.props.get("buildpath") match {
+  case Some(p) => p
+  case None => throw new IllegalArgumentException("must specify -Dbuildpath=")
+}
 
 // Look for the dynet_swig jar file there.
 unmanagedBase := file( buildPath ).getAbsoluteFile


### PR DESCRIPTION
not 100% thrilled with the failure mode here (also not 100% thrilled with the fact that the scala compilation takes place in the builddir even if you do `sbt run` from the `swig` directory), but it does the right things in re hardcoding the directory and having make not touch anything outside of `build`