### PR TITLE
don't include scala libraries in the jar

### DIFF
--- a/swig/build.sbt
+++ b/swig/build.sbt
@@ -20,5 +20,10 @@ assemblyOutputPath in assembly := file(s"${buildPath}/dynet_swigJNI_scala.jar").
 
 fork in run := true
 
+// Don't include Scala libraries in the jar
+// see https://github.com/sbt/sbt-assembly/issues/3
+// and http://stackoverflow.com/questions/15856739/assembling-a-jar-containing-only-the-provided-dependencies
+assembleArtifact in packageScala := false
+
 // And look there for java libraries when running.
 javaOptions in run += s"-Djava.library.path=${buildPath}"


### PR DESCRIPTION
by default, `sbt assembly` includes lots of basic scala libraries in the jar. all this stuff shouldn't be necessary if you're going to use the jar from scala. this change reduces the uberjar size from 5MB to like 50kb.