### PR TITLE
implement java.io.Serializable on the Model wrapper class

### DIFF
--- a/swig/dynet_swig.i
+++ b/swig/dynet_swig.i
@@ -12,6 +12,9 @@
 // Required header files for compiling wrapped code
 %{
 #include <vector>
+#include <sstream>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
 #include "model.h"
 #include "tensor.h"
 #include "dynet.h"
@@ -38,7 +41,6 @@ static void myInitialize()  {
 %include "std_vector.i"
 %include "std_string.i"
 %include "std_pair.i"
-
 
 struct dynet::expr::Expression;
 
@@ -152,6 +154,33 @@ class Model {
 
 void save_dynet_model(std::string filename, Model* model);
 void load_dynet_model(std::string filename, Model* model);
+
+// extra code to serialize / deserialize strings
+
+%{
+
+namespace dynet {
+
+std::string serialize_to_string(Model* model) {
+    std::ostringstream out;
+    boost::archive::text_oarchive oa(out);
+    oa << (*model);
+    return out.str();
+}
+
+void deserialize_from_string(std::string serialized, Model* model) {
+    std::istringstream in;
+    in.str(serialized);
+    boost::archive::text_iarchive ia(in);
+    ia >> (*model);
+}
+
+}
+%}
+
+std::string serialize_to_string(Model* model);
+void deserialize_from_string(std::string serialized, Model* model);
+
 
 // declarations from dynet/tensor.h
 

--- a/swig/src/test/scala/edu/cmu/dynet/SerializationSpec.scala
+++ b/swig/src/test/scala/edu/cmu/dynet/SerializationSpec.scala
@@ -23,7 +23,7 @@ class SerializationSpec extends FlatSpec with Matchers {
 
   "dynet" should "create models with the right number of parameters" in {
     val model = defaultModel()
-    model.parameter_count() shouldBe 11  // == 2 * 3 * 5
+    model.parameter_count() shouldBe 11  // == 2 * 3 + 5
   }
 
   "dynet" should "serialize models to/from disk" in {

--- a/swig/src/test/scala/edu/cmu/dynet/SerializationSpec.scala
+++ b/swig/src/test/scala/edu/cmu/dynet/SerializationSpec.scala
@@ -9,7 +9,7 @@ class SerializationSpec extends FlatSpec with Matchers {
 
   myInitialize()
 
-  "dynet" should "correctly serialize and deserialize" in {
+  "dynet" should "correctly serialize and deserialize to disk" in {
     val original = new Model()
 
     // Add parameters
@@ -25,4 +25,21 @@ class SerializationSpec extends FlatSpec with Matchers {
     load_dynet_model(path, deserialized)
     deserialized.parameter_count() shouldBe 11  // == 2 * 3 + 5
   }
+
+  "dynet" should "correctly serialize and deserialize from string" in {
+    val original = new Model()
+
+    // Add parameters
+    original.add_parameters(dim(2, 3))
+    original.add_parameters(dim(5))
+
+    // Serialize to string
+    val modelAsString = serialize_to_string(original)
+
+    // Deserialize from string
+    val deserialized = new Model()
+    deserialize_from_string(modelAsString, deserialized)
+    deserialized.parameter_count() shouldBe 11  // == 2 * 3 + 5
+  }
+
 }

--- a/swig/src/test/scala/edu/cmu/dynet/SerializationSpec.scala
+++ b/swig/src/test/scala/edu/cmu/dynet/SerializationSpec.scala
@@ -9,12 +9,25 @@ class SerializationSpec extends FlatSpec with Matchers {
 
   myInitialize()
 
-  "dynet" should "correctly serialize and deserialize to disk" in {
-    val original = new Model()
+  def assertSameModel(m1: Model, m2: Model): Assertion = {
+    // TODO(joelgrus): add more logic here as we add more methods to the Java API
+    m1.parameter_count() shouldBe m2.parameter_count()
+  }
 
-    // Add parameters
-    original.add_parameters(dim(2, 3))
-    original.add_parameters(dim(5))
+  def defaultModel(): Model = {
+    val model = new Model()
+    model.add_parameters(dim(2, 3))
+    model.add_parameters(dim(5))
+    model
+  }
+
+  "dynet" should "create models with the right number of parameters" in {
+    val model = defaultModel()
+    model.parameter_count() shouldBe 11  // == 2 * 3 * 5
+  }
+
+  "dynet" should "serialize models to/from disk" in {
+    val original = defaultModel()
 
     // Save to a temp file
     val path = java.io.File.createTempFile("dynet_test", "serialization_spec").getAbsolutePath
@@ -23,23 +36,32 @@ class SerializationSpec extends FlatSpec with Matchers {
     // Deserialize
     val deserialized = new Model()
     load_dynet_model(path, deserialized)
-    deserialized.parameter_count() shouldBe 11  // == 2 * 3 + 5
+
+    assertSameModel(original, deserialized)
   }
 
-  "dynet" should "correctly serialize and deserialize from string" in {
-    val original = new Model()
+  "dynet" should "serialize models to/from string when called explicitly" in {
 
-    // Add parameters
-    original.add_parameters(dim(2, 3))
-    original.add_parameters(dim(5))
+    val original = defaultModel()
 
-    // Serialize to string
-    val modelAsString = serialize_to_string(original)
+    val s = original.serialize_to_string()
 
-    // Deserialize from string
-    val deserialized = new Model()
-    deserialize_from_string(modelAsString, deserialized)
-    deserialized.parameter_count() shouldBe 11  // == 2 * 3 + 5
+    val deserialized = new Model
+    deserialized.load_from_string(s)
+    assertSameModel(original, deserialized)
   }
 
+  "dynet" should "correctly implement java serialization" in {
+
+    val original = defaultModel()
+
+    val path = java.io.File.createTempFile("dynet_test", "serialization_spec").getAbsolutePath
+    val oos = new java.io.ObjectOutputStream(new java.io.FileOutputStream(path))
+    oos.writeObject(original)
+    oos.close()
+
+    val ois = new java.io.ObjectInputStream(new java.io.FileInputStream(path))
+    val deserialized = ois.readObject.asInstanceOf[Model]
+    assertSameModel(original, deserialized)
+  }
 }


### PR DESCRIPTION
this was more difficult than it should have been. 

the primary serialization that comes with dynet is `save_dynet_model(filename, model)`, which uses Boost serialization and stores the result in a file as plaintext. I did the following:

* implemented C++ analogues of save/load_dynet_model that just return / accept the serialized string
* implemented Java writeObject/readObject methods that convert the model to/from a string and use Java String serialization on that
* added code to `readObject` that makes sure the underlying C++ model is initialized

and, of course, tests to make sure it works

