### PR TITLE
Add float pointer support, fix XOR example

### DIFF
--- a/swig/dynet_swig.i
+++ b/swig/dynet_swig.i
@@ -41,6 +41,10 @@ static void myInitialize()  {
 %include "std_vector.i"
 %include "std_string.i"
 %include "std_pair.i"
+%include "cpointer.i"
+
+%pointer_functions(int, intp);
+%pointer_functions(float, floatp);
 
 struct dynet::expr::Expression;
 
@@ -218,27 +222,27 @@ namespace expr {
 struct Expression {
   ComputationGraph *pg;
   VariableIndex i;
-  Expression(ComputationGraph *pg, VariableIndex i) : pg(pg), i(i) { }
-  //const Tensor& value() const { return pg->get_value(i); }
+  Expression(ComputationGraph *pg, VariableIndex i) : pg(pg), i(i) { };
+  const Tensor& value();
 };
 
 // %template(ExpressionVector)     ::std::vector<Expression>;
 
 Expression input(ComputationGraph& g, real s);
 Expression input(ComputationGraph& g, const real *ps);
-Expression input(ComputationGraph& g, const Dim& d, const std::vector<float>& data);
-//Expression input(ComputationGraph& g, const Dim& d, const std::vector<float>* pdata);
+//Expression input(ComputationGraph& g, const Dim& d, const std::vector<float>& data);
+Expression input(ComputationGraph& g, const Dim& d, const std::vector<float>* pdata);
 Expression input(ComputationGraph& g, const Dim& d, const std::vector<unsigned int>& ids, const std::vector<float>& data, float defdata = 0.f);
 Expression parameter(ComputationGraph& g, Parameter p);
 Expression const_parameter(ComputationGraph& g, Parameter p);
-Expression lookup(ComputationGraph& g, LookupParameter p, unsigned index);
-//Expression lookup(ComputationGraph& g, LookupParameter p, const unsigned* pindex);
-Expression const_lookup(ComputationGraph& g, LookupParameter p, unsigned index);
-//Expression const_lookup(ComputationGraph& g, LookupParameter p, const unsigned* pindex);
-Expression lookup(ComputationGraph& g, LookupParameter p, const std::vector<unsigned>& indices);
-//Expression lookup(ComputationGraph& g, LookupParameter p, const std::vector<unsigned>* pindices);
-Expression const_lookup(ComputationGraph& g, LookupParameter p, const std::vector<unsigned>& indices);
-//Expression const_lookup(ComputationGraph& g, LookupParameter p, const std::vector<unsigned>* pindices);
+//Expression lookup(ComputationGraph& g, LookupParameter p, unsigned index);
+Expression lookup(ComputationGraph& g, LookupParameter p, const unsigned* pindex);
+//Expression const_lookup(ComputationGraph& g, LookupParameter p, unsigned index);
+Expression const_lookup(ComputationGraph& g, LookupParameter p, const unsigned* pindex);
+//Expression lookup(ComputationGraph& g, LookupParameter p, const std::vector<unsigned>& indices);
+Expression lookup(ComputationGraph& g, LookupParameter p, const std::vector<unsigned>* pindices);
+//Expression const_lookup(ComputationGraph& g, LookupParameter p, const std::vector<unsigned>& indices);
+Expression const_lookup(ComputationGraph& g, LookupParameter p, const std::vector<unsigned>* pindices);
 Expression zeroes(ComputationGraph& g, const Dim& d);
 Expression random_normal(ComputationGraph& g, const Dim& d);
 

--- a/swig/src/main/scala/edu/cmu/dynet/examples/XorScala.scala
+++ b/swig/src/main/scala/edu/cmu/dynet/examples/XorScala.scala
@@ -29,7 +29,10 @@ object XorScala {
 
     val x_values = new FloatVector(2)
     val x = input(cg, dim(2), x_values)
-    var y_value = 0f
+
+    // Need a pointer representation of scalars so updates are tracked
+    val y_value = new_floatp()
+    floatp_assign(y_value, 0)
     val y = input(cg, y_value)
 
     val h = tanh(W * x + b)
@@ -49,7 +52,9 @@ object XorScala {
         val x2: Boolean = (mi / 2) % 2 > 0
         x_values.set(0, if (x1) 1 else -1)
         x_values.set(1, if (x2) 1 else -1)
-        y_value = if (x1 != x2) 1 else -1
+        floatp_assign(y_value, if (x1 != x2) 1 else -1)
+        // Clear cached computations since we have changed the inputs
+        cg.invalidate()
         loss += as_scalar(cg.forward(loss_expr))
         cg.backward(loss_expr)
         sgd.update(1.0f)


### PR DESCRIPTION
This uses Joel's findings on pointers and fixes some of the bindings (such as `input(...)`) to track changes in the underlying vectors, so that the XOR example should now do what it's supposed to do (instead of just running with 0's everywhere!).