### PR TITLE
add pointer helpers / fix java example

### DIFF
--- a/swig/src/main/java/edu/cmu/dynet/examples/XorExample.java
+++ b/swig/src/main/java/edu/cmu/dynet/examples/XorExample.java
@@ -45,7 +45,8 @@ public class XorExample {
     Expression x = input(cg, makeDim(new int[]{2}), x_values);
 
     // Output value
-    float y_value = 0f;
+    SWIGTYPE_p_float y_value = new_floatp();
+    floatp_assign(y_value, 0f);
     Expression y = input(cg, y_value);
 
     // Hidden perceptron layer
@@ -72,7 +73,7 @@ public class XorExample {
         boolean x2 = (mi / 2) % 2 > 0;
         x_values.set(0, x1 ? 1 : -1);
         x_values.set(1, x2 ? 1 : -1);
-        y_value = (x1 != x2) ? 1 : -1;
+        floatp_assign(y_value, (x1 != x2) ? 1 : -1);
         loss += as_scalar(cg.forward(loss_expr));
         cg.backward(loss_expr);
         sgd.update(1.0f);

--- a/swig/src/main/scala/edu/cmu/dynet/DynetScalaHelpers.scala
+++ b/swig/src/main/scala/edu/cmu/dynet/DynetScalaHelpers.scala
@@ -6,6 +6,28 @@ import scala.language.implicitConversions
 
 object DynetScalaHelpers {
 
+  // The SWIG wrappers around pointers to C++ primitives are not very Scala-like to work with,
+  // these are more Scala-y wrappers that implicitly converts to the SWIG version.
+  class FloatPointer {
+    val floatp = new_floatp
+
+    def set(value: Float) = floatp_assign(floatp, value)
+
+    def value() = floatp_value(floatp)
+  }
+
+  implicit def toFloatp(fp: FloatPointer): SWIGTYPE_p_float = fp.floatp
+
+  class IntPointer {
+    val intp = new_intp
+
+    def set(value: Int) = intp_assign(intp, value)
+
+    def value() = intp_value(intp)
+  }
+
+  implicit def toIntp(ip: IntPointer): SWIGTYPE_p_int = ip.intp
+
   def dim(dims: Int*): Dim = {
     val dimInts = new LongVector
     dims.foreach(dimInts.add)

--- a/swig/src/main/scala/edu/cmu/dynet/DynetScalaHelpers.scala
+++ b/swig/src/main/scala/edu/cmu/dynet/DynetScalaHelpers.scala
@@ -11,9 +11,9 @@ object DynetScalaHelpers {
   class FloatPointer {
     val floatp = new_floatp
 
-    def set(value: Float) = floatp_assign(floatp, value)
+    def set(value: Float): Unit = floatp_assign(floatp, value)
 
-    def value() = floatp_value(floatp)
+    def value(): Float = floatp_value(floatp)
   }
 
   implicit def toFloatp(fp: FloatPointer): SWIGTYPE_p_float = fp.floatp
@@ -21,9 +21,9 @@ object DynetScalaHelpers {
   class IntPointer {
     val intp = new_intp
 
-    def set(value: Int) = intp_assign(intp, value)
+    def set(value: Int): Unit = intp_assign(intp, value)
 
-    def value() = intp_value(intp)
+    def value(): Int = intp_value(intp)
   }
 
   implicit def toIntp(ip: IntPointer): SWIGTYPE_p_int = ip.intp

--- a/swig/src/main/scala/edu/cmu/dynet/DynetScalaHelpers.scala
+++ b/swig/src/main/scala/edu/cmu/dynet/DynetScalaHelpers.scala
@@ -6,8 +6,8 @@ import scala.language.implicitConversions
 
 object DynetScalaHelpers {
 
-  // The SWIG wrappers around pointers to C++ primitives are not very Scala-like to work with,
-  // these are more Scala-y wrappers that implicitly converts to the SWIG version.
+  // The SWIG wrappers around pointers to C++ primitives are not very Scala-like to work with;
+  // these are more Scala-y wrappers that implicitly convert to the SWIG versions.
   class FloatPointer {
     val floatp = new_floatp
 

--- a/swig/src/main/scala/edu/cmu/dynet/examples/XorScala.scala
+++ b/swig/src/main/scala/edu/cmu/dynet/examples/XorScala.scala
@@ -31,8 +31,8 @@ object XorScala {
     val x = input(cg, dim(2), x_values)
 
     // Need a pointer representation of scalars so updates are tracked
-    val y_value = new_floatp()
-    floatp_assign(y_value, 0)
+    val y_value = new FloatPointer
+    y_value.set(0)
     val y = input(cg, y_value)
 
     val h = tanh(W * x + b)
@@ -52,7 +52,7 @@ object XorScala {
         val x2: Boolean = (mi / 2) % 2 > 0
         x_values.set(0, if (x1) 1 else -1)
         x_values.set(1, if (x2) 1 else -1)
-        floatp_assign(y_value, if (x1 != x2) 1 else -1)
+        y_value.set(if (x1 != x2) 1 else -1)
         // Clear cached computations since we have changed the inputs
         cg.invalidate()
         loss += as_scalar(cg.forward(loss_expr))


### PR DESCRIPTION
I added some ScalaHelpers to make working with the SWIG pointer types easier. I'm not wedded to this API, it seemed reasonable, but if you have suggestions on how to improve it I'll take them.

I also fixed the Java XOR example.