### PR TITLE
put java jar in /javajar directory, scala jar in /scalajar

### DIFF
--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -22,6 +22,9 @@ swig_add_module(dynet_swig java dynet_swig.i)
 # Link with dynet library
 swig_link_libraries(dynet_swig dynet)
 
+# Add a directory for the java jar
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/javajar)
+
 # Create jar file
 add_jar(
     dynet_swigJNI
@@ -55,7 +58,14 @@ add_jar(
     "${CMAKE_SWIG_OUTDIR}/SWIGTYPE_p_unsigned_int.java"
     "${CMAKE_SWIG_OUTDIR}/Tensor.java"
     "${CMAKE_SWIG_OUTDIR}/Trainer.java"
+    OUTPUT_DIR
+    "${CMAKE_CURRENT_BINARY_DIR}/javajar"
 )
+
+// Since the jar is going in javajar, we need to move the .jnilib file there too.
+file(RENAME
+     "${CMAKE_CURRENT_BINARY_DIR}/libdynet_swig.jnilib"
+     "${CMAKE_CURRENT_BINARY_DIR}/javajar/libdynet_swig.jnilib")
 
 # TODO(joelgrus): This is probably not defensive or robust enough.
 option(INCLUDE_SCALA_HELPERS "INCLUDE_SCALA_HELPERS" ON)
@@ -72,7 +82,7 @@ if(INCLUDE_SCALA_HELPERS)
     COMMENT "Running sbt"
     OUTPUT scala_helper_uberjar
     DEPENDS dynet_swigJNI
-    COMMAND ${SBT} assembly -Dbuildpath=${CMAKE_CURRENT_BINARY_DIR}
+    COMMAND ${SBT} assembly -Dbuildpath=${CMAKE_CURRENT_BINARY_DIR}/javajar
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
   )
 

--- a/swig/README.md
+++ b/swig/README.md
@@ -18,9 +18,9 @@ build$ cmake .. -DEIGEN3_INCLUDE_DIR=../eigen -DINCLUDE_SWIG=ON
 build$ make dynet_swig && make
 ```
 
-In MacOS, this will create the library files `dynet_swigJNI.jar` and `libdynet_swig.jnilib` in the `build/swig` directory. 
+In MacOS, this will create the library files `dynet_swigJNI.jar` and `libdynet_swig.jnilib` in the `build/swig/javajar` directory. 
 It will then run `sbt assembly` to produce an "uberjar" containing 
-both the Dynet bindings and the scala helpers, also in `build/swig`.
+both the Dynet bindings and the scala helpers, in `build/swig/scalajar`.
 
 If you don't want the Scala helpers (and, in particular, if you
 don't have `sbt`) then when you run `cmake` include the additional flag
@@ -50,15 +50,15 @@ If successful, the end of the build should look something like:
 After running `make`, you can run the Scala examples under the `swig` directory with `sbt`:
 
 ```
-swig$ sbt "runMain edu.cmu.dynet.examples.XorScala" -Dbuildpath=../build/swig
-swig$ sbt "runMain edu.cmu.dynet.examples.LinearRegression" -Dbuildpath=../build/swig
+swig$ sbt "runMain edu.cmu.dynet.examples.XorScala"
+swig$ sbt "runMain edu.cmu.dynet.examples.LinearRegression"
 ```
 
 The Java example takes a couple more steps:
 
 ```
-swig$ javac -d . -cp ../build/swig/dynet_swigJNI.jar src/main/java/edu/cmu/dynet/examples/XorExample.java
-swig$ java -cp .:../build/swig/dynet_swigJNI.jar -Djava.library.path=../build/swig edu.cmu.dynet.examples.XorExample
+swig$ javac -d . -cp ../build/swig/javajar/dynet_swigJNI.jar src/main/java/edu/cmu/dynet/examples/XorExample.java
+swig$ java -cp .:../build/swig/javajar/dynet_swigJNI.jar -Djava.library.path=../build/swig/javajar edu.cmu.dynet.examples.XorExample
 Running XOR example
 [dynet] random seed: 1650744221
 [dynet] allocating memory: 512MB

--- a/swig/build.sbt
+++ b/swig/build.sbt
@@ -3,7 +3,7 @@ name := "dynet_scala_helpers"
 
 scalaVersion := "2.11.8"
 
-val DEFAULT_BUILD_PATH = "../build/swig"
+val DEFAULT_BUILD_PATH = "../build/swig/javajar"
 
 // This is where `make` does all its work, and it's where we'll do all our work as well.
 val buildPath = {
@@ -28,7 +28,8 @@ unmanagedBase := file( buildPath ).getAbsoluteFile
 target := file(s"${buildPath}/target/")
 
 // Put the uberjar there.
-assemblyOutputPath in assembly := file(s"${buildPath}/dynet_swigJNI_scala.jar").getAbsoluteFile
+assemblyOutputPath in assembly := file(s"${buildPath}/../scalajar/dynet_swigJNI_scala.jar")
+    .getAbsoluteFile
 
 fork := true
 


### PR DESCRIPTION
this should fix your problem, but it still feels ugly to me, as a background task we should see if we can come up with a cleaner way to handle all this.