### PR TITLE
back to one directory

### DIFF
--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -22,9 +22,6 @@ swig_add_module(dynet_swig java dynet_swig.i)
 # Link with dynet library
 swig_link_libraries(dynet_swig dynet)
 
-# Add a directory for the java jar
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/javajar)
-
 # Create jar file
 add_jar(
     dynet_swigJNI
@@ -58,14 +55,7 @@ add_jar(
     "${CMAKE_SWIG_OUTDIR}/SWIGTYPE_p_unsigned_int.java"
     "${CMAKE_SWIG_OUTDIR}/Tensor.java"
     "${CMAKE_SWIG_OUTDIR}/Trainer.java"
-    OUTPUT_DIR
-    "${CMAKE_CURRENT_BINARY_DIR}/javajar"
 )
-
-// Since the jar is going in javajar, we need to move the .jnilib file there too.
-file(RENAME
-     "${CMAKE_CURRENT_BINARY_DIR}/libdynet_swig.jnilib"
-     "${CMAKE_CURRENT_BINARY_DIR}/javajar/libdynet_swig.jnilib")
 
 # TODO(joelgrus): This is probably not defensive or robust enough.
 option(INCLUDE_SCALA_HELPERS "INCLUDE_SCALA_HELPERS" ON)
@@ -82,12 +72,11 @@ if(INCLUDE_SCALA_HELPERS)
     COMMENT "Running sbt"
     OUTPUT scala_helper_uberjar
     DEPENDS dynet_swigJNI
-    COMMAND ${SBT} assembly -Dbuildpath=${CMAKE_CURRENT_BINARY_DIR}/javajar
+    COMMAND ${SBT} assembly -Dbuildpath=${CMAKE_CURRENT_BINARY_DIR}
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
   )
 
   add_custom_target(scala_helper ALL DEPENDS scala_helper_uberjar)
 
 endif()
-
 

--- a/swig/README.md
+++ b/swig/README.md
@@ -18,9 +18,9 @@ build$ cmake .. -DEIGEN3_INCLUDE_DIR=../eigen -DINCLUDE_SWIG=ON
 build$ make dynet_swig && make
 ```
 
-In MacOS, this will create the library files `dynet_swigJNI.jar` and `libdynet_swig.jnilib` in the `build/swig/javajar` directory. 
+In MacOS, this will create the library files `dynet_swigJNI.jar` and `libdynet_swig.jnilib` in the `build/swig` directory. 
 It will then run `sbt assembly` to produce an "uberjar" containing 
-both the Dynet bindings and the scala helpers, in `build/swig/scalajar`.
+both the Dynet bindings and the scala helpers, also in `build/swig`.
 
 If you don't want the Scala helpers (and, in particular, if you
 don't have `sbt`) then when you run `cmake` include the additional flag
@@ -57,8 +57,8 @@ swig$ sbt "runMain edu.cmu.dynet.examples.LinearRegression"
 The Java example takes a couple more steps:
 
 ```
-swig$ javac -d . -cp ../build/swig/javajar/dynet_swigJNI.jar src/main/java/edu/cmu/dynet/examples/XorExample.java
-swig$ java -cp .:../build/swig/javajar/dynet_swigJNI.jar -Djava.library.path=../build/swig/javajar edu.cmu.dynet.examples.XorExample
+swig$ javac -d . -cp ../build/swig/dynet_swigJNI.jar src/main/java/edu/cmu/dynet/examples/XorExample.java
+swig$ java -cp .:../build/swig/dynet_swigJNI.jar -Djava.library.path=../build/swig edu.cmu.dynet.examples.XorExample
 Running XOR example
 [dynet] random seed: 1650744221
 [dynet] allocating memory: 512MB

--- a/swig/build.sbt
+++ b/swig/build.sbt
@@ -3,7 +3,7 @@ name := "dynet_scala_helpers"
 
 scalaVersion := "2.11.8"
 
-val DEFAULT_BUILD_PATH = "../build/swig/javajar"
+val DEFAULT_BUILD_PATH = "../build/swig"
 
 // This is where `make` does all its work, and it's where we'll do all our work as well.
 val buildPath = {
@@ -21,6 +21,10 @@ val buildPath = {
   }
 }
 
+val uberjarPath = s"${buildPath}/dynet_swigJNI_scala.jar"
+
+excludeFilter in unmanagedJars := "dynet_swigJNI_scala.jar"
+
 // Look for the dynet_swig jar file there.
 unmanagedBase := file( buildPath ).getAbsoluteFile
 
@@ -28,10 +32,31 @@ unmanagedBase := file( buildPath ).getAbsoluteFile
 target := file(s"${buildPath}/target/")
 
 // Put the uberjar there.
-assemblyOutputPath in assembly := file(s"${buildPath}/../scalajar/dynet_swigJNI_scala.jar")
-    .getAbsoluteFile
+assemblyOutputPath in assembly := file(uberjarPath).getAbsoluteFile
 
 fork := true
+
+val removeUberjar = taskKey[Unit]("Remove Uberjar")
+
+removeUberjar := {
+  val uberjar = new java.io.File(uberjarPath)
+  if (uberjar.exists()) {
+    println("removing uberjar")
+    uberjar.delete()
+  } else {
+    println("nothing to remove")
+  }
+}
+
+assembly := {
+  removeUberjar.value
+  assembly.value
+}
+
+clean := {
+  removeUberjar.value
+  clean.value
+}
 
 // Don't include Scala libraries in the jar
 // see https://github.com/sbt/sbt-assembly/issues/3


### PR DESCRIPTION
I think the /javajar /scalajar made things worse in a lot of ways (also, as pradeep's email implicitly pointed out, it was coupled to the OSX version). 

I reverted to the previous way (everything in `build/swig`), but I modified build.sbt to

* ignore the scala jar, and
* delete it as the first step of the `clean` and `assembly` tasks

probably they're not both necessary, but they're both "right", and I think this will fix your problem