### PR TITLE
add java.util.Collection constructors for _Vector types

### DIFF
--- a/swig/dynet_swig.i
+++ b/swig/dynet_swig.i
@@ -37,6 +37,28 @@ static void myInitialize()  {
 }
 %}
 
+//
+// Macro to generate extra vector constructors that take a java Collection,
+// needs to be declared + used before we include "std_vector.i"
+//
+
+%define VECTORCONSTRUCTOR(ctype, javatype, vectortype)
+%typemap(javacode) std::vector<ctype> %{
+  public vectortype(java.util.Collection<javatype> values) {
+     this(values.size());
+     int i = 0;
+     for (java.util.Iterator<javatype> it = values.iterator(); it.hasNext(); i++) {
+         javatype value = it.next();
+         this.set(i, value);
+     }
+  }
+%}
+%enddef
+
+VECTORCONSTRUCTOR(float, Float, FloatVector)
+VECTORCONSTRUCTOR(double, Double, DoubleVector)
+VECTORCONSTRUCTOR(int, Integer, IntVector)
+
 // Useful SWIG libraries
 %include "std_vector.i"
 %include "std_string.i"

--- a/swig/src/main/scala/edu/cmu/dynet/DynetScalaHelpers.scala
+++ b/swig/src/main/scala/edu/cmu/dynet/DynetScalaHelpers.scala
@@ -6,6 +6,27 @@ import scala.language.implicitConversions
 
 object DynetScalaHelpers {
 
+  import scala.collection.JavaConverters._
+  import java.util.Collection
+
+  // The collection constructors for the _Vector types require java.util.Collection[javatype] input,
+  // so here are some implicit conversions from Seq[scalatype] to make them easier to work with
+  implicit def convertFloatsToFloats(values: Seq[Float]): Collection[java.lang.Float] = {
+    values.map(float2Float).asJavaCollection
+  }
+
+  implicit def convertDoublesToFloats(values: Seq[Double]): Collection[java.lang.Float] = {
+    convertFloatsToFloats(values.map(_.toFloat))
+  }
+
+  implicit def convertDoublesToDoubles(values: Seq[Double]): Collection[java.lang.Double] = {
+    values.map(double2Double).asJavaCollection
+  }
+
+  implicit def convertIntsToIntegers(values: Seq[Int]): Collection[java.lang.Integer] = {
+    values.map(int2Integer).asJavaCollection
+  }
+
   // The SWIG wrappers around pointers to C++ primitives are not very Scala-like to work with;
   // these are more Scala-y wrappers that implicitly convert to the SWIG versions.
   class FloatPointer {

--- a/swig/src/test/scala/edu/cmu/dynet/VectorSpec.scala
+++ b/swig/src/test/scala/edu/cmu/dynet/VectorSpec.scala
@@ -1,0 +1,44 @@
+package edu.cmu.dynet
+
+import org.scalatest._
+import edu.cmu.dynet._
+import edu.cmu.dynet.dynet_swig._
+
+class VectorSpec extends FlatSpec with Matchers {
+
+  import DynetScalaHelpers._
+
+  "FloatVector" should "construct when given a Seq[Float]" in {
+    val fv = new FloatVector(Seq(2.3f, 4.5f))
+
+    fv.size shouldBe 2
+    fv.get(0) shouldBe 2.3f
+    fv.get(1) shouldBe 4.5f
+  }
+
+  "FloatVector" should "construct when given a Seq[Double]" in {
+    val fv = new FloatVector(Seq(2.3, 4.5))
+
+    fv.size shouldBe 2
+    fv.get(0) shouldBe 2.3f
+    fv.get(1) shouldBe 4.5f
+  }
+
+  "DoubleVector" should "construct when given a Seq[Double]" in {
+    val dv = new DoubleVector(Seq(2.3, 4.5, -10.2))
+
+    dv.size shouldBe 3
+    dv.get(0) shouldBe 2.3
+    dv.get(1) shouldBe 4.5
+    dv.get(2) shouldBe -10.2
+  }
+
+  "IntVector" should "construct when given a Seq[Int]" in {
+    val iv = new IntVector(Seq(23, 45, -102))
+
+    iv.size shouldBe 3
+    iv.get(0) shouldBe 23
+    iv.get(1) shouldBe 45
+    iv.get(2) shouldBe -102
+  }
+}


### PR DESCRIPTION
and implicit conversions to allow you to things like `val v = FloatVector(Seq(2.3, 3.4))`.

I think this is the API we were discussing yesterday, let me know if you think it should be something different. also, I only did `FloatVector`, `IntVector` and `DoubleVector`, but at this point it's easy to add more, let me know if you think that would be useful