### PR TITLE
add bindings and tests for ParameterInit classes

### DIFF
--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -40,6 +40,15 @@ add_jar(
     "${CMAKE_SWIG_OUTDIR}/LSTMBuilder.java"
     "${CMAKE_SWIG_OUTDIR}/Model.java"
     "${CMAKE_SWIG_OUTDIR}/Parameter.java"
+    "${CMAKE_SWIG_OUTDIR}/ParameterInit.java"
+    "${CMAKE_SWIG_OUTDIR}/ParameterInitNormal.java"
+    "${CMAKE_SWIG_OUTDIR}/ParameterInitUniform.java"
+    "${CMAKE_SWIG_OUTDIR}/ParameterInitConst.java"
+    "${CMAKE_SWIG_OUTDIR}/ParameterInitIdentity.java"
+    "${CMAKE_SWIG_OUTDIR}/ParameterInitGlorot.java"
+    # "${CMAKE_SWIG_OUTDIR}/ParameterInitSaxe.java" (I AM NOT ACTUALLY IMPLEMENTED IN DYNET)
+    "${CMAKE_SWIG_OUTDIR}/ParameterInitFromFile.java"
+    "${CMAKE_SWIG_OUTDIR}/ParameterInitFromVector.java"
     "${CMAKE_SWIG_OUTDIR}/RNNBuilder.java"
     "${CMAKE_SWIG_OUTDIR}/SimpleSGDTrainer.java"
     "${CMAKE_SWIG_OUTDIR}/StringVector.java"
@@ -54,6 +63,7 @@ add_jar(
     "${CMAKE_SWIG_OUTDIR}/SWIGTYPE_p_std__vectorT_unsigned_int_t.java"
     "${CMAKE_SWIG_OUTDIR}/SWIGTYPE_p_unsigned_int.java"
     "${CMAKE_SWIG_OUTDIR}/Tensor.java"
+    "${CMAKE_SWIG_OUTDIR}/TensorTools.java"
     "${CMAKE_SWIG_OUTDIR}/Trainer.java"
 )
 

--- a/swig/dynet_swig.i
+++ b/swig/dynet_swig.i
@@ -251,6 +251,71 @@ struct LookupParameterStorage : public ParameterStorageBase {
 };
 */
 
+struct ParameterInit {
+  ParameterInit() {}
+  virtual ~ParameterInit() {}
+  virtual void initialize_params(Tensor & values) const = 0;
+};
+
+struct ParameterInitNormal : public ParameterInit {
+  ParameterInitNormal(float m = 0.0f, float v = 1.0f) : mean(m), var(v) {}
+  virtual void initialize_params(Tensor& values) const override;
+ private:
+  float mean, var;
+};
+
+struct ParameterInitUniform : public ParameterInit {
+  ParameterInitUniform(float scale) :
+    left(-scale), right(scale) { assert(scale != 0.0f); }
+  ParameterInitUniform(float l, float r) : left(l), right(r) { assert(l != r); }
+  virtual void initialize_params(Tensor & values) const override;
+ private:
+  float left, right;
+};
+
+struct ParameterInitConst : public ParameterInit {
+  ParameterInitConst(float c) : cnst(c) {}
+  virtual void initialize_params(Tensor & values) const override;
+private:
+  float cnst;
+};
+
+struct ParameterInitIdentity : public ParameterInit {
+  ParameterInitIdentity() {}
+  virtual void initialize_params(Tensor & values) const override;
+};
+
+struct ParameterInitGlorot : public ParameterInit {
+  ParameterInitGlorot(bool is_lookup = false) : lookup(is_lookup) {}
+  virtual void initialize_params(Tensor & values) const override;
+private:
+  bool lookup;
+};
+
+/* I AM NOT ACTUALLY IMPLEMENTED IN THE DYNET CODE
+struct ParameterInitSaxe : public ParameterInit {
+  ParameterInitSaxe() {}
+  virtual void initialize_params(Tensor & values) const override;
+private:
+  float cnst;
+};
+*/
+
+struct ParameterInitFromFile : public ParameterInit {
+  ParameterInitFromFile(std::string f) : filename(f) {}
+  virtual void initialize_params(Tensor & values) const override;
+private:
+  std::string filename;
+};
+
+struct ParameterInitFromVector : public ParameterInit {
+  ParameterInitFromVector(std::vector<float> v) : vec(v) {}
+  virtual void initialize_params(Tensor & values) const override;
+private:
+  std::vector<float> vec;
+};
+
+
 class Model {
  public:
   Model();
@@ -296,6 +361,10 @@ struct Tensor {
 
 real as_scalar(const Tensor& t);
 std::vector<real> as_vector(const Tensor& v);
+
+struct TensorTools {
+  static float AccessElement(const Tensor& v, const Dim& index);
+};
 
 // declarations from dynet/expr.h
 

--- a/swig/src/main/scala/edu/cmu/dynet/DynetScalaHelpers.scala
+++ b/swig/src/main/scala/edu/cmu/dynet/DynetScalaHelpers.scala
@@ -62,6 +62,10 @@ object DynetScalaHelpers {
   implicit class Untensor(t: Tensor) {
     def toFloat: Float = as_scalar(t)
     def toVector: FloatVector = as_vector(t)
+    def toSeq: Seq[Float] = {
+      val vector = t.toVector
+      for (i <- 0 until vector.size.toInt) yield vector.get(i)
+    }
   }
 
   implicit class RichExpression(e: Expression) {

--- a/swig/src/main/scala/edu/cmu/dynet/examples/LinearRegression.scala
+++ b/swig/src/main/scala/edu/cmu/dynet/examples/LinearRegression.scala
@@ -6,7 +6,6 @@ import edu.cmu.dynet.dynet_swig._
 import scala.language.implicitConversions
 
 object LinearRegression {
-  // Right now these are defined in XorScala.scala
   import DynetScalaHelpers._
 
   def main(args: Array[String]) {

--- a/swig/src/test/scala/edu/cmu/dynet/ParameterInitSpec.scala
+++ b/swig/src/test/scala/edu/cmu/dynet/ParameterInitSpec.scala
@@ -30,14 +30,14 @@ class ParameterInitSpec extends FlatSpec with Matchers {
 
     val values = p_W.values.toSeq
 
-    // Really weak bounds on the sample mean and variance, basically just a sanity check.
+    // Incredibly weak bounds on the sample mean and variance, basically just a sanity check.
     val mean = values.sum / 10000
-    mean > 9  shouldBe true
-    mean < 11 shouldBe true
+    mean > 7  shouldBe true
+    mean < 13 shouldBe true
 
     val s2 = values.map(v => scala.math.pow(v - mean, 2)).sum / 9999f
-    s2 > 3 shouldBe true
-    s2 < 5 shouldBe true
+    s2 > 2 shouldBe true
+    s2 < 6 shouldBe true
   }
 
   "ParameterInitUniform" should "initialize things uniformly" in {
@@ -53,16 +53,14 @@ class ParameterInitSpec extends FlatSpec with Matchers {
     values.max <= 17 shouldBe true
     values.min >= 12 shouldBe true
 
-    // Really weak bounds on the sample mean and variance, basically just a sanity check.
+    // Incredibly weak bounds on the sample mean and variance, basically just a sanity check.
     val mean = values.sum / 10000
-    mean > 14 shouldBe true
-    mean < 15 shouldBe true
+    mean > 13 shouldBe true
+    mean < 16 shouldBe true
 
-    // Theoretical variance is 25/12
-    val s2 = values.map(v => scala.math.pow(v - mean, 2)).sum / 9999f
-    s2 > 20 / 12f shouldBe true
-    s2 < 30 / 12f shouldBe true
-
+    // Must take on values in the top / bottom quartile
+    values.exists(v => v > 15.75) shouldBe true
+    values.exists(v => v < 13.25) shouldBe true
   }
 
   "ParameterInitIdentity" should "initialize to the identity matrix" in {
@@ -117,11 +115,11 @@ class ParameterInitSpec extends FlatSpec with Matchers {
 
     // reasonable looking mean
     val mean = values.sum / 100
-    mean <  0.2 shouldBe true
-    mean > -0.2 shouldBe true
+    mean <  0.3 shouldBe true
+    mean > -0.3 shouldBe true
 
-    // but some dispersion (values in lowest / highest quartiles)
-    values.exists(v => v > s  / 2) shouldBe true
-    values.exists(v => v < -s / 2) shouldBe true
+    // but some dispersion
+    values.exists(v => v > s  / 4) shouldBe true
+    values.exists(v => v < -s / 4) shouldBe true
   }
 }

--- a/swig/src/test/scala/edu/cmu/dynet/ParameterInitSpec.scala
+++ b/swig/src/test/scala/edu/cmu/dynet/ParameterInitSpec.scala
@@ -1,0 +1,127 @@
+package edu.cmu.dynet
+
+import org.scalatest._
+import edu.cmu.dynet._
+import edu.cmu.dynet.dynet_swig._
+
+class ParameterInitSpec extends FlatSpec with Matchers {
+
+  import DynetScalaHelpers._
+  myInitialize()
+
+  "ParameterInitConst" should "set constant values" in {
+    val model = new Model
+    val p_W = model.add_parameters(dim(10))
+
+    val init = new ParameterInitConst(10.0f)
+    init.initialize_params(p_W.values)
+
+    // All values should be initialized to 10.0f
+    p_W.values.toSeq.foreach(x => x shouldBe 10.0f)
+  }
+
+  "ParameterInitNormal" should "initialize things normally" in {
+    val model = new Model
+    val p_W = model.add_parameters(dim(10000))
+
+    // mean 10, variance 4
+    val init = new ParameterInitNormal(10, 4)
+    init.initialize_params(p_W.values)
+
+    val values = p_W.values.toSeq
+
+    // Really weak bounds on the sample mean and variance, basically just a sanity check.
+    val mean = values.sum / 10000
+    mean > 9  shouldBe true
+    mean < 11 shouldBe true
+
+    val s2 = values.map(v => scala.math.pow(v - mean, 2)).sum / 9999f
+    s2 > 3 shouldBe true
+    s2 < 5 shouldBe true
+  }
+
+  "ParameterInitUniform" should "initialize things uniformly" in {
+    val model = new Model
+    val p_W = model.add_parameters(dim(10000))
+
+    // uniform from 12 to 17
+    val init = new ParameterInitUniform(12f, 17f)
+    init.initialize_params(p_W.values)
+
+    val values = p_W.values.toSeq
+
+    values.max <= 17 shouldBe true
+    values.min >= 12 shouldBe true
+
+    // Really weak bounds on the sample mean and variance, basically just a sanity check.
+    val mean = values.sum / 10000
+    mean > 14 shouldBe true
+    mean < 15 shouldBe true
+
+    // Theoretical variance is 25/12
+    val s2 = values.map(v => scala.math.pow(v - mean, 2)).sum / 9999f
+    s2 > 20 / 12f shouldBe true
+    s2 < 30 / 12f shouldBe true
+
+  }
+
+  "ParameterInitIdentity" should "initialize to the identity matrix" in {
+    val model = new Model
+    val p_W = model.add_parameters(dim(100, 100))
+
+    val init = new ParameterInitIdentity()
+    init.initialize_params(p_W.values)
+
+    for {
+      i <- 0 until 100
+      j <- 0 until 100
+      z = if (i == j) 1f else 0f
+    } {
+      TensorTools.AccessElement(p_W.values, dim(i, j)) shouldBe z
+    }
+  }
+
+  "ParameterInitFromVector" should "initialize from a vector" in {
+    val model = new Model
+    val p_W = model.add_parameters(dim(1000))
+
+    val valuesIn = (1 to 1000).map(x => math.sin(x).toFloat)
+    val vector = new FloatVector(valuesIn)
+    val init = new ParameterInitFromVector(vector)
+
+    init.initialize_params(p_W.values)
+
+    val valuesOut = p_W.values.toSeq
+
+    valuesIn.zip(valuesOut).foreach {
+      case (vi, vo) => vi shouldBe vo
+    }
+  }
+
+  "ParameterInitGlorot" should "initialize using the correct distribution" in {
+    val model = new Model
+    val p_W = model.add_parameters(dim(20, 5))
+
+    val init = new ParameterInitGlorot()
+
+    init.initialize_params(p_W.values)
+
+    // should be uniform [-s, s] where s = sqrt(6) / sqrt(25) = sqrt(6) / 5
+    val s = math.sqrt(6) / 5 // ~ 0.4899
+
+    val values = p_W.values.toSeq
+
+    // within the bounds
+    values.min > -s shouldBe true
+    values.max <  s shouldBe true
+
+    // reasonable looking mean
+    val mean = values.sum / 100
+    mean <  0.2 shouldBe true
+    mean > -0.2 shouldBe true
+
+    // but some dispersion (values in lowest / highest quartiles)
+    values.exists(v => v > s  / 2) shouldBe true
+    values.exists(v => v < -s / 2) shouldBe true
+  }
+}


### PR DESCRIPTION
a lot of these are random initialization (e.g. normal with specified mean and variance), so I wrote tests with very weak bounds that (hopefully) should always pass (probability of failing on the order of 10^-10 or smaller) but also sanity-check the randomness logic

(I also had to add one TensorTools method for the test and a .toSeq helper)