### PR TITLE
ExpressionVector and logsumexp binding

### DIFF
--- a/swig/dynet_swig.i
+++ b/swig/dynet_swig.i
@@ -58,6 +58,7 @@ static void myInitialize()  {
 VECTORCONSTRUCTOR(float, Float, FloatVector)
 VECTORCONSTRUCTOR(double, Double, DoubleVector)
 VECTORCONSTRUCTOR(int, Integer, IntVector)
+VECTORCONSTRUCTOR(dynet::expr::Expression, Expression, ExpressionVector)
 
 // Useful SWIG libraries
 %include "std_vector.i"

--- a/swig/dynet_swig.i
+++ b/swig/dynet_swig.i
@@ -436,6 +436,11 @@ Expression block_dropout(const Expression& x, real p);
 
 Expression softmax(const Expression& x);
 Expression log_softmax(const Expression& x);
+
+template <typename T>
+Expression logsumexp(const T& xs);
+%template(logsumexp_VE) logsumexp<std::vector<Expression>>;
+
 Expression pickneglogsoftmax(const Expression& x, unsigned v);
 
 template <typename T>


### PR DESCRIPTION
The *_VE function names generated by the templates are a bit ugly. Let's think about how to clean these up in the future.