### PR TITLE
add bindings for all the "Builders" + fix .back() issue

### DIFF
--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -51,6 +51,7 @@ add_jar(
     "${CMAKE_SWIG_OUTDIR}/ParameterInitFromFile.java"
     "${CMAKE_SWIG_OUTDIR}/ParameterInitFromVector.java"
     "${CMAKE_SWIG_OUTDIR}/RNNBuilder.java"
+    "${CMAKE_SWIG_OUTDIR}/SimpleRNNBuilder.java"
     "${CMAKE_SWIG_OUTDIR}/SimpleSGDTrainer.java"
     "${CMAKE_SWIG_OUTDIR}/StringVector.java"
     "${CMAKE_SWIG_OUTDIR}/SWIGTYPE_p_dynet__LookupParameterStorage.java"
@@ -67,6 +68,7 @@ add_jar(
     "${CMAKE_SWIG_OUTDIR}/TensorTools.java"
     "${CMAKE_SWIG_OUTDIR}/Trainer.java"
     "${CMAKE_SWIG_OUTDIR}/UnsignedVector.java"
+    "${CMAKE_SWIG_OUTDIR}/VanillaLSTMBuilder.java"
 )
 
 # TODO(joelgrus): This is probably not defensive or robust enough.

--- a/swig/src/main/scala/edu/cmu/dynet/DynetScalaHelpers.scala
+++ b/swig/src/main/scala/edu/cmu/dynet/DynetScalaHelpers.scala
@@ -136,13 +136,6 @@ object DynetScalaHelpers {
     }
   }
 
-  // In C++, LSTMBuilder has a back() method that returns an Expression struct by value. SWIG
-  // can't deal with that, so instead we expose the two elements of that struct and then use
-  // this implicit class to create a back() function that mimics the C++ functionality.
-  implicit class LSTMBuilderBack(b: LSTMBuilder) {
-    def back(): Expression = new Expression(b.back_graph, b.back_index)
-  }
-
   def affine_transform(es: Seq[Expression]): Expression = {
     val ev = new ExpressionVector
     es.foreach(e => ev.add(e))


### PR DESCRIPTION
all of the bindings from http://dynet.readthedocs.io/en/latest/builders.html

also, it turns out that SWIG's issue with `back()` (which returned a struct by value) was caused by the fact that the SWIG bindings (copied from the relevant .h file) included an inline definition. 

when I changed it to just the plain declaration, the java wrappers now do the right thing (return a new `Expression` object and delete the underlying C++ object when the the Java object gets garbage collected). accordingly, I got rid of the `back_graph` and `back_pointer` methods and the corresponding scala helper