### PR TITLE
replace myInitialize with explicit initialization with DynetParams

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -175,8 +175,11 @@ add_subdirectory(python)
 
 option(INCLUDE_SWIG "INCLUDE_SWIG" OFF)
 if(INCLUDE_SWIG)
+  if (WITH_CUDA_BACKEND)
+    set(CMAKE_SWIG_FLAGS "-DSWIG_USE_CUDA")    
+  endif(WITH_CUDA_BACKEND)
   message("-- Including SWIG")
   add_subdirectory(swig)
-endif()
+endif(INCLUDE_SWIG)
 
 enable_testing()

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -34,6 +34,7 @@ add_jar(
     "${CMAKE_SWIG_OUTDIR}/DoubleVector.java"
     "${CMAKE_SWIG_OUTDIR}/dynet_swig.java"
     "${CMAKE_SWIG_OUTDIR}/dynet_swigJNI.java"
+    "${CMAKE_SWIG_OUTDIR}/DynetParams.java"
     "${CMAKE_SWIG_OUTDIR}/Expression.java"
     "${CMAKE_SWIG_OUTDIR}/ExpressionVector.java"
     "${CMAKE_SWIG_OUTDIR}/FloatVector.java"

--- a/swig/dynet_swig.i
+++ b/swig/dynet_swig.i
@@ -24,19 +24,6 @@
 #include "lstm.h"
 %}
 
-// Extra C++ code added
-%{
-namespace dynet {
-
-// Convenience function for testing
-static void myInitialize()  {
-  char** argv = {NULL};
-  int argc = 0;
-  initialize(argc, argv);
-};
-}
-%}
-
 //
 // Macro to generate extra vector constructors that take a java Collection,
 // needs to be declared + used before we include "std_vector.i"
@@ -862,18 +849,26 @@ struct VanillaLSTMBuilder : public RNNBuilder {
 // declarations from dynet/init.h //
 ////////////////////////////////////
 
+struct DynetParams {
+  unsigned random_seed = 0; /**< The seed for random number generation */
+  std::string mem_descriptor = "512"; /**< Total memory to be allocated for Dynet */
+  float weight_decay = 0; /**< Weight decay rate for L2 regularization */
+  bool shared_parameters = false; /**< TO DOCUMENT */
+
+#if SWIG_USE_CUDA
+  bool ngpus_requested = false; /**< GPUs requested by number */
+  bool ids_requested = false; /**< GPUs requested by ids */
+  int requested_gpus = -1; /**< Number of requested GPUs */
+  std::vector<int> gpu_mask; /**< List of required GPUs by ids */
+#endif
+};
+
+
+void initialize(DynetParams params);
 void initialize(int& argc, char**& argv, bool shared_parameters = false);
 void cleanup();
 
-/////////////////////////////
-// additional declarations //
-/////////////////////////////
-
-static void myInitialize();
-
 }
-
-
 
 
 

--- a/swig/src/main/java/edu/cmu/dynet/examples/XorExample.java
+++ b/swig/src/main/java/edu/cmu/dynet/examples/XorExample.java
@@ -20,7 +20,7 @@ public class XorExample {
 
   public static void main(String[] args) {
     System.out.println("Running XOR example");
-    myInitialize();
+    initialize(new DynetParams());
     System.out.println("Dynet initialized!");
     Model m = new Model();
     SimpleSGDTrainer sgd = new SimpleSGDTrainer(m);

--- a/swig/src/main/scala/edu/cmu/dynet/DynetScalaHelpers.scala
+++ b/swig/src/main/scala/edu/cmu/dynet/DynetScalaHelpers.scala
@@ -6,6 +6,17 @@ import scala.language.implicitConversions
 
 object DynetScalaHelpers {
 
+  var initialized = false
+
+  def myInitialize(): Unit = {
+    if (initialized) {
+      println("already initialized")
+    } else {
+      initialized = true
+      initialize(new DynetParams())
+    }
+  }
+
   import scala.collection.JavaConverters._
   import java.util.Collection
 


### PR DESCRIPTION
but add back in `myInitialize` scala helper that does the same (so current examples will keep working if they use the scala helpers)

(also requires adding a CUDA flag for swig, which might come in handy if we do a GPU version)

(the C++ side is weird in that it uses conditional compilation to give `DynetParams` a different *definition* in the GPU case. I followed that, but if you think that's weird, let me know.)