### PR TITLE
Serializing byte[] and objects

### DIFF
--- a/swig/dynet_swig.i
+++ b/swig/dynet_swig.i
@@ -59,7 +59,6 @@ VECTORCONSTRUCTOR(std::vector<dynet::Parameter>, ParameterVector, ParameterVecto
 
 // Useful SWIG libraries
 %include "std_vector.i"
-%include "various.i"
 %include "std_string.i"
 %include "std_pair.i"
 %include "cpointer.i"
@@ -981,7 +980,10 @@ void cleanup();
       objOut.writeObject(o);
       objOut.close();
 
-      add_byte_array(out.toByteArray());
+      byte[] bytes = out.toByteArray();
+
+      add_size(bytes.length);
+      add_byte_array(bytes);
     } catch (IOException e) {
       // This shouldn't ever happen.
       throw new RuntimeException(e);
@@ -1074,13 +1076,10 @@ struct ModelLoader {
 }
 %}
 
-// %apply unsigned char *NIOBUFFER { unsigned char *buf };
+// Convert methods whose arguments are (char *str, size_t len)
+// to byte[] in Java. Note that the *argument names must match*,
+// not just the types.
 %apply(char *STRING, size_t LENGTH) { (char *str, size_t len) }
-
-%typemap(jstype) char *load_byte_array() "byte[]";
-%typemap(javaout) char *load_byte_array() {
-  return $jnicall.getBytes();
-}
 
 %nodefaultctor ModelSaver;
 struct ModelSaver {
@@ -1107,9 +1106,6 @@ struct ModelSaver {
 %newobject ModelLoader::load_srnn_builder();
 %newobject ModelLoader::load_gru_builder();
 %newobject ModelLoader::load_fast_lstm_builder();
-
-// Do we need to declare this?
-// %newobject ModelLoader::load_string();
 
 
 %nodefaultctor ModelLoader;

--- a/swig/dynet_swig.i
+++ b/swig/dynet_swig.i
@@ -970,11 +970,10 @@ void cleanup();
   import java.io.ByteArrayOutputStream;
   import java.io.ObjectOutputStream;
   import java.io.IOException;
-  import java.io.Serializable;
 %}
  
 %typemap(javacode) ModelSaver %{
-  public void add_object(Serializable o) {
+  public void add_object(Object o) {
     try {
       ByteArrayOutputStream out = new ByteArrayOutputStream();
       ObjectOutputStream objOut = new ObjectOutputStream(out);

--- a/swig/dynet_swig.i
+++ b/swig/dynet_swig.i
@@ -991,6 +991,34 @@ void cleanup();
   }
 %}
 
+%typemap(javaimports) ModelLoader %{
+  import java.io.ByteArrayInputStream;
+  import java.io.ObjectInputStream;
+  import java.io.IOException;
+%}
+
+%typemap(javacode) ModelLoader %{
+  public Object load_object() {
+    long size = load_size();
+    byte[] bytes = new byte[(int) size];
+    load_bytes(bytes);
+
+    Object obj = null;
+    try {
+      ByteArrayInputStream in = new ByteArrayInputStream(bytes);
+      ObjectInputStream objIn = new ObjectInputStream(in);
+      obj = objIn.readObject();
+      objIn.close();
+    } catch (IOException e) {
+      // This shouldn't ever happen.
+      throw new RuntimeException(e);
+    }
+
+    return obj;
+  }
+%}
+
+
 %{
   
 namespace dynet {

--- a/swig/dynet_swig.i
+++ b/swig/dynet_swig.i
@@ -970,10 +970,11 @@ void cleanup();
   import java.io.ByteArrayOutputStream;
   import java.io.ObjectOutputStream;
   import java.io.IOException;
+  import java.io.Serializable;
 %}
  
 %typemap(javacode) ModelSaver %{
-  public void add_object(Object o) {
+  public void add_object(Serializable o) {
     try {
       ByteArrayOutputStream out = new ByteArrayOutputStream();
       ObjectOutputStream objOut = new ObjectOutputStream(out);
@@ -998,10 +999,10 @@ void cleanup();
 %}
 
 %typemap(javacode) ModelLoader %{
-  public Object load_object() {
+  public <T> T load_object(Class<T> clazz) {
     long size = load_size();
     byte[] bytes = new byte[(int) size];
-    load_bytes(bytes);
+    load_byte_array(bytes);
 
     Object obj = null;
     try {
@@ -1012,9 +1013,11 @@ void cleanup();
     } catch (IOException e) {
       // This shouldn't ever happen.
       throw new RuntimeException(e);
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
     }
 
-    return obj;
+    return clazz.cast(obj);
   }
 %}
 

--- a/swig/dynet_swig.i
+++ b/swig/dynet_swig.i
@@ -1005,8 +1005,8 @@ struct ModelSaver {
     void add_srnn_builder(SimpleRNNBuilder &p) { oa << p; }
     void add_gru_builder(GRUBuilder &p) { oa << p; }
     void add_fast_lstm_builder(FastLSTMBuilder &p) { oa << p; }
+    void add_size(size_t len) { oa << len; }
     void add_byte_array(char *str, size_t len) {
-      oa << len;
       oa << boost::serialization::make_array(str, len);
     }
 
@@ -1053,14 +1053,14 @@ struct ModelLoader {
       FastLSTMBuilder* p = new FastLSTMBuilder(); ia >> *p; return p;
     }
 
-    char* load_byte_array() {
+    size_t load_size() {
       size_t len;
       ia >> len;
+      return len;
+    }
 
-      char* buf = new char[len];
-      ia >> boost::serialization::make_array(buf, len);
-
-      return buf;
+    void load_byte_array(char *str, size_t len) {
+      ia >> boost::serialization::make_array(str, len);
     }
 
     void done() { ifs.close(); }
@@ -1093,6 +1093,7 @@ struct ModelSaver {
     void add_srnn_builder(SimpleRNNBuilder &p);
     void add_gru_builder(GRUBuilder &p);
     void add_fast_lstm_builder(FastLSTMBuilder &p);
+    void add_size(size_t len) { oa << len; }
     void add_byte_array(char *str, size_t len);
     void done();
 };
@@ -1122,7 +1123,8 @@ struct ModelLoader {
     SimpleRNNBuilder* load_srnn_builder();
     GRUBuilder* load_gru_builder();
     FastLSTMBuilder* load_fast_lstm_builder();
-    char* load_byte_array();
+    size_t load_size();
+    void load_byte_array(char *str, size_t len);
     void done();
 };
 

--- a/swig/dynet_swig.i
+++ b/swig/dynet_swig.i
@@ -63,7 +63,6 @@ VECTORCONSTRUCTOR(std::vector<dynet::Parameter>, ParameterVector, ParameterVecto
 %include "std_pair.i"
 %include "cpointer.i"
 
-
 %pointer_functions(unsigned, uintp);
 %pointer_functions(int, intp);
 %pointer_functions(float, floatp);
@@ -966,6 +965,7 @@ void cleanup();
 // serialization logic (from python/pybridge.h) //
 //////////////////////////////////////////////////
 
+// Add Java method to ModelSaver for serializing java objects.
 %typemap(javaimports) ModelSaver %{
   import java.io.ByteArrayOutputStream;
   import java.io.ObjectOutputStream;
@@ -992,6 +992,7 @@ void cleanup();
   }
 %}
 
+// Add Java method to ModelLoader for loading java objects. 
 %typemap(javaimports) ModelLoader %{
   import java.io.ByteArrayInputStream;
   import java.io.ObjectInputStream;
@@ -1014,6 +1015,7 @@ void cleanup();
       // This shouldn't ever happen.
       throw new RuntimeException(e);
     } catch (ClassNotFoundException e) {
+      // This also shouldn't happen (because the class is an argument).
       throw new RuntimeException(e);
     }
 
@@ -1156,7 +1158,6 @@ struct ModelLoader {
 };
 
 }
-
 
 
 

--- a/swig/src/test/scala/edu/cmu/dynet/LinearRegressionSpec.scala
+++ b/swig/src/test/scala/edu/cmu/dynet/LinearRegressionSpec.scala
@@ -20,16 +20,18 @@ class LinearRegressionSpec extends FlatSpec with Matchers {
 
     val model = new Model
     val trainer = new SimpleSGDTrainer(model, 0.01f)
-    val cg = ComputationGraph.getNew
 
     val p_W = model.add_parameters(dim(1))
-    val W = parameter(cg, p_W)
-
     val p_b = model.add_parameters(dim(1))
-    val b = parameter(cg, p_b)
 
+    val examples = xs.zip(ys)
+    
     for (iter <- 1 to numIterations) {
-      for ((x, y) <- xs.zip(ys)) {
+      for ((x, y) <- examples) {
+        val cg = ComputationGraph.getNew
+        val W = parameter(cg, p_W)
+        val b = parameter(cg, p_b)
+
         val prediction = W * x + b
         val loss = square(prediction - y)
         cg.forward(loss)

--- a/swig/src/test/scala/edu/cmu/dynet/SerializationSpec.scala
+++ b/swig/src/test/scala/edu/cmu/dynet/SerializationSpec.scala
@@ -3,6 +3,7 @@ package edu.cmu.dynet
 import org.scalatest._
 import edu.cmu.dynet._
 import edu.cmu.dynet.dynet_swig._
+import java.util.Arrays
 
 class SerializationSpec extends FlatSpec with Matchers {
   import DynetScalaHelpers._
@@ -149,4 +150,43 @@ class SerializationSpec extends FlatSpec with Matchers {
 
     assertSameModel(mod1, mod2)
   }
+  
+  "model saver and model loader" should "handle byte[] correctly" in {
+
+    val s = Array[Byte](3, 7, 127, 2, 5, 8, 0, -1, -2)
+
+    val path = java.io.File.createTempFile("dynet_test", "serialization_spec").getAbsolutePath
+    val saver = new ModelSaver(path)
+    saver.add_byte_array(s)
+    saver.done()
+
+    val loader = new ModelLoader(path)
+    val s2 = loader.load_byte_array()
+    loader.done()
+    
+    System.out.println(Arrays.toString(s))
+    System.out.println(Arrays.toString(s2))
+
+    Arrays.equals(s, s2) shouldBe true
+  }
+
+  /*
+  "model saver and model loader" should "handle java objects correctly" in {
+    
+    case class Foo(a: String, b: Int) extends Serializable 
+
+    val s = new Foo("abcd", 78)
+
+    val path = java.io.File.createTempFile("dynet_test", "serialization_spec").getAbsolutePath
+    val saver = new ModelSaver(path)
+    saver.add_object(s)
+    saver.done()
+
+    val loader = new ModelLoader(path)
+    val s2 = loader.load_string()
+    loader.done()
+
+    s2 shouldBe s
+  }
+*/
 }

--- a/swig/src/test/scala/edu/cmu/dynet/SerializationSpec.scala
+++ b/swig/src/test/scala/edu/cmu/dynet/SerializationSpec.scala
@@ -166,18 +166,11 @@ class SerializationSpec extends FlatSpec with Matchers {
     val s2 = Array.ofDim[Byte](length.asInstanceOf[Int])
     loader.load_byte_array(s2)
     loader.done()
-    
-    System.out.println(Arrays.toString(s))
-    System.out.println(Arrays.toString(s2))
 
     Arrays.equals(s, s2) shouldBe true
   }
 
-  /*
-  "model saver and model loader" should "handle java objects correctly" in {
-    
-    case class Foo(a: String, b: Int) extends Serializable 
-
+  "model saver and model loader" should "handle objects correctly" in {
     val s = new Foo("abcd", 78)
 
     val path = java.io.File.createTempFile("dynet_test", "serialization_spec").getAbsolutePath
@@ -186,10 +179,11 @@ class SerializationSpec extends FlatSpec with Matchers {
     saver.done()
 
     val loader = new ModelLoader(path)
-    val s2 = loader.load_string()
+    val s2 = loader.load_object(classOf[Foo])
     loader.done()
 
     s2 shouldBe s
   }
-*/
 }
+
+case class Foo(a: String, b: Int) extends Serializable

--- a/swig/src/test/scala/edu/cmu/dynet/SerializationSpec.scala
+++ b/swig/src/test/scala/edu/cmu/dynet/SerializationSpec.scala
@@ -153,15 +153,18 @@ class SerializationSpec extends FlatSpec with Matchers {
   
   "model saver and model loader" should "handle byte[] correctly" in {
 
-    val s = Array[Byte](3, 7, 127, 2, 5, 8, 0, -1, -2)
+    val s = Array[Byte](3, 7, 127, 2, 5, 8, 0, -1, -2, 100, 10, -2, 0)
 
     val path = java.io.File.createTempFile("dynet_test", "serialization_spec").getAbsolutePath
     val saver = new ModelSaver(path)
+    saver.add_size(s.length)
     saver.add_byte_array(s)
     saver.done()
 
     val loader = new ModelLoader(path)
-    val s2 = loader.load_byte_array()
+    val length = loader.load_size()
+    val s2 = Array.ofDim[Byte](length.asInstanceOf[Int])
+    loader.load_byte_array(s2)
     loader.done()
     
     System.out.println(Arrays.toString(s))


### PR DESCRIPTION
This change allows us to serialize objects into ModelSaver. Getting this working in swig turned out to be nontrivial because Java objects get serialized to byte[], which need to be mapped to char* and a length in C++. Note that the load_byte_array method has a different signature from the others because there's no good way to return a newly allocated byte[] from C++.

I also fixed the LinearRegression test case so it runs much faster.