### PR TITLE
Serialization for primitive types

### DIFF
--- a/swig/dynet_swig.i
+++ b/swig/dynet_swig.i
@@ -1044,6 +1044,13 @@ struct ModelSaver {
       oa << boost::serialization::make_array(str, len);
     }
 
+    // primitive types
+    void add_int(int x) { oa << x; }
+    void add_long(jlong x) { oa << x; }
+    void add_float(float x) { oa << x; }
+    void add_double(double x) { oa << x; }
+    void add_boolean(jboolean x) { oa << x; }
+
     void done() { ofs.close(); }
 
     private:
@@ -1097,6 +1104,12 @@ struct ModelLoader {
       ia >> boost::serialization::make_array(str, len);
     }
 
+    int load_int() { int x; ia >> x; return x; }
+    jlong load_long() { long x; ia >> x; return x; }
+    float load_float() { float x; ia >> x; return x; }
+    double load_double() { double x; ia >> x; return x; }
+    jboolean load_boolean() { bool x; ia >> x; return x; }
+
     void done() { ifs.close(); }
 
     private:
@@ -1126,6 +1139,13 @@ struct ModelSaver {
     void add_fast_lstm_builder(FastLSTMBuilder &p);
     void add_size(size_t len) { oa << len; }
     void add_byte_array(char *str, size_t len);
+
+    void add_int(int x);
+    void add_long(jlong x);
+    void add_float(float x);
+    void add_double(double x);
+    void add_boolean(jboolean x);
+
     void done();
 };
 
@@ -1153,6 +1173,13 @@ struct ModelLoader {
     FastLSTMBuilder* load_fast_lstm_builder();
     size_t load_size();
     void load_byte_array(char *str, size_t len);
+
+    int load_int();
+    jlong load_long();
+    float load_float();
+    double load_double();
+    jboolean load_boolean();
+
     void done();
 };
 

--- a/swig/src/test/scala/edu/cmu/dynet/SerializationSpec.scala
+++ b/swig/src/test/scala/edu/cmu/dynet/SerializationSpec.scala
@@ -184,6 +184,31 @@ class SerializationSpec extends FlatSpec with Matchers {
 
     s2 shouldBe s
   }
+
+  "model saver and model loader" should "handle primitives correctly" in {
+    val path = java.io.File.createTempFile("dynet_test", "serialization_spec").getAbsolutePath
+    val saver = new ModelSaver(path)
+    saver.add_int(0)
+    saver.add_int(-123)
+    saver.add_int(256)
+    saver.add_long(-23L)
+    saver.add_float(256.123f)
+    saver.add_double(-12.54)
+    saver.add_boolean(true)
+    saver.add_boolean(false)
+    saver.done()
+
+    val loader = new ModelLoader(path)
+    loader.load_int() shouldBe 0
+    loader.load_int() shouldBe -123
+    loader.load_int() shouldBe 256
+    loader.load_long() shouldBe -23L
+    loader.load_float() shouldBe 256.123f
+    loader.load_double() shouldBe -12.54
+    loader.load_boolean() shouldBe true
+    loader.load_boolean() shouldBe false
+    loader.done()
+  }
 }
 
 case class Foo(a: String, b: Int) extends Serializable


### PR DESCRIPTION
Serializing these as objects leads to casting friction between java/scala -- e.g., boolean gets saved as java.lang.Boolean, which fails to load with load_object(classOf[Boolean]).