### PR TITLE
load dynamic library from a jar

### DIFF
--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -104,6 +104,14 @@ add_jar(
     "${CMAKE_SWIG_OUTDIR}/VanillaLSTMBuilder.java"
 )
 
+# Add dynamic library files into the Jar
+add_custom_target(
+    dylib_into_jar
+    # COMMAND zip -j ${CMAKE_CURRENT_BINARY_DIR}/dynet_swigJNI.jar ${CMAKE_CURRENT_BINARY_DIR}/libdynet_swig.*
+    COMMAND zip -j ${CMAKE_CURRENT_BINARY_DIR}/dynet_swigJNI_dylib.jar ${CMAKE_CURRENT_BINARY_DIR}/libdynet_swig.*
+)
+add_dependencies(dylib_into_jar dynet_swigJNI)
+
 # TODO(joelgrus): This is probably not defensive or robust enough.
 option(INCLUDE_SCALA_HELPERS "INCLUDE_SCALA_HELPERS" ON)
 if(INCLUDE_SCALA_HELPERS)
@@ -118,7 +126,7 @@ if(INCLUDE_SCALA_HELPERS)
   add_custom_command(
     COMMENT "Running sbt"
     OUTPUT scala_helper_uberjar
-    DEPENDS dynet_swigJNI
+    DEPENDS dylib_into_jar
     COMMAND ${SBT} assembly -Dbuildpath=${CMAKE_CURRENT_BINARY_DIR}
     WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
   )

--- a/swig/CMakeLists.txt
+++ b/swig/CMakeLists.txt
@@ -107,7 +107,6 @@ add_jar(
 # Add dynamic library files into the Jar
 add_custom_target(
     dylib_into_jar
-    # COMMAND zip -j ${CMAKE_CURRENT_BINARY_DIR}/dynet_swigJNI.jar ${CMAKE_CURRENT_BINARY_DIR}/libdynet_swig.*
     COMMAND zip -j ${CMAKE_CURRENT_BINARY_DIR}/dynet_swigJNI_dylib.jar ${CMAKE_CURRENT_BINARY_DIR}/libdynet_swig.*
 )
 add_dependencies(dylib_into_jar dynet_swigJNI)

--- a/swig/README.md
+++ b/swig/README.md
@@ -18,7 +18,11 @@ build$ cmake .. -DEIGEN3_INCLUDE_DIR=../../eigen -DINCLUDE_SWIG=ON
 build$ make dynet_swig && make
 ```
 
-In MacOS, this will create the library files `dynet_swigJNI.jar` and `libdynet_swig.jnilib` in the `build/swig` directory. 
+This will create `dynet_swigJNI.jar` in the `build/swig` directory.
+(It also produces a dynamic library file, but the `make` process puts
+ that file into the jar as a resource, and the code to load that library
+ looks for it in the jar, so you don't need to worry about it.)
+
 It will then run `sbt assembly` to produce an "uberjar" containing 
 both the Dynet bindings and the scala helpers, also in `build/swig`.
 
@@ -65,7 +69,7 @@ The Java example takes a couple more steps:
 
 ```
 swig$ javac -d . -cp ../build/swig/dynet_swigJNI.jar src/main/java/edu/cmu/dynet/examples/XorExample.java
-swig$ java -cp .:../build/swig/dynet_swigJNI.jar -Djava.library.path=../build/swig edu.cmu.dynet.examples.XorExample
+swig$ java -cp .:../build/swig/dynet_swigJNI.jar edu.cmu.dynet.examples.XorExample
 Running XOR example
 [dynet] random seed: 1650744221
 [dynet] allocating memory: 512MB

--- a/swig/build.sbt
+++ b/swig/build.sbt
@@ -1,7 +1,10 @@
-
-name := "dynet_scala_helpers"
-
-scalaVersion := "2.11.8"
+lazy val root = (project in file("."))
+    .settings(
+      name         := "dynet_scala_helpers",
+      organization := "edu.cmu.dynet",
+      scalaVersion := "2.11.8",
+      version      := "0.0.1-SNAPSHOT"
+    )
 
 val DEFAULT_BUILD_PATH = "../build/swig"
 
@@ -26,7 +29,7 @@ val uberjarPath = s"${buildPath}/dynet_swigJNI_scala.jar"
 excludeFilter in unmanagedJars := "dynet_swigJNI_scala.jar"
 
 // Look for the dynet_swig jar file there.
-unmanagedBase := file( buildPath ).getAbsoluteFile
+//unmanagedBase := file( buildPath ).getAbsoluteFile
 
 // Put all of the sbt generated classes there.
 target := file(s"${buildPath}/target/")
@@ -58,12 +61,18 @@ clean := {
   clean.value
 }
 
+assemblyMergeStrategy in assembly := {
+  case "libdynet_swig.jnilib" => MergeStrategy.discard
+  case "libdynet_swig.so"     => MergeStrategy.discard
+  case example if example.contains("/examples/") => MergeStrategy.discard
+  case x =>
+    val oldStrategy = (assemblyMergeStrategy in assembly).value
+    oldStrategy(x)
+}
+
 // Don't include Scala libraries in the jar
 // see https://github.com/sbt/sbt-assembly/issues/3
 // and http://stackoverflow.com/questions/15856739/assembling-a-jar-containing-only-the-provided-dependencies
 assembleArtifact in packageScala := false
-
-// And look there for java libraries when running.
-javaOptions += s"-Djava.library.path=${buildPath}"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.0" % "test"

--- a/swig/build.sbt
+++ b/swig/build.sbt
@@ -27,9 +27,10 @@ val buildPath = {
 val uberjarPath = s"${buildPath}/dynet_swigJNI_scala.jar"
 
 excludeFilter in unmanagedJars := "dynet_swigJNI_scala.jar"
+excludeFilter in unmanagedSources := HiddenFileFilter || "*.dylib" || "*.so"
 
 // Look for the dynet_swig jar file there.
-//unmanagedBase := file( buildPath ).getAbsoluteFile
+unmanagedBase  := file( buildPath ).getAbsoluteFile
 
 // Put all of the sbt generated classes there.
 target := file(s"${buildPath}/target/")


### PR DESCRIPTION
thanks to the links Oyvind sent me, I was able to get this working. basically, here's what happens:

* the `make` process creates an additional jar `dynet_swig_JNI_dylib.jar` that only contains the dynamic library file (.dylib or .so) as a resource
* the static jni initialization code now looks for that resource, writes the contents to a temp file, and calls `System.load` on that temp file
* and we have to tell sbt to ignore those resources when it's assembling the "with scala helpers" jar

my thinking is that then we can publish the `dynet_swigJNI_scala.jar` as one managed dependency, and then we can also publish a variety of platform/cpu/gpu-specific versions of the dylib.jar, so that then you could do something like

```
libraryDependencies += "edu.cmu.dynet" %% "dynet_scala" % "0.0.1"
libraryDependencies += "edu.cmu.dynet" %% "dynet_native_osx_cpu" % "0.0.1"
```

let me know what you think about this approach; also, we should talk about how high priority it is to get all this various stuff published in bintray, vs just letting people build it themselves. maintaining all these various versions will be kind of a pain.
