### PR TITLE
add missing bindings, rename RichNumeric

### DIFF
--- a/contrib/swig/README.md
+++ b/contrib/swig/README.md
@@ -2,7 +2,10 @@
 
 The code in `dynet_swig.i` provides SWIG instructions to wrap salient
 parts of DyNet for use in other languages, in particular Scala (and
-Java). It produces Java (in `edu.cmu.dynet.internal`) that slavishly
+Java). These bindings were developed (and are maintained) by
+researchers from the [Allen Institute for Artificial Intelligence](http://allenai.org).
+
+The SWIG bindings produce Java (in `edu.cmu.dynet.internal`) that slavishly
 recreates the C++ API, and that you should strive not to use.
 
 Instead you should use the Scala API that lives in `edu.cmu.dynet`.
@@ -88,6 +91,36 @@ difference is that the `DynetParams` class has additional fields in
 the GPU version for configuring the GPU. This difference shouldn't
 affect you unless you want to configure these parameters and also run
 the same code on the CPU.
+
+## Modifying the Bindings
+
+As more functionality is added to (C++) DyNet, corresponding changes 
+will need to be made to these bindings. Here is how to update the Scala
+bindings for (say) a new class `NewClass`:
+
+### In `dynet_swig.i`
+
+* Make sure that the `.i` file `#include`s the relevant C++ header file
+  (if it doesn't already)
+* Declare the class and whatever methods you want wrappers for in the 
+  `.i` file. (The existing declarations should be a good guide.)
+
+### In `CMakeLists.txt`
+
+* SWIG will generate an intermediate `NewClass.java` file; add it to the
+  `add_jar` directive
+  
+### In Scala
+
+* create a Scala class with a private constructor that wraps the SWIG-generated
+  `internal.NewClass`. Expose Scala-y secondary constructors and/or factory methods
+  for Scala code to use. Hide all `internal.` details:
+
+```
+private[dynet] class NewClass(private[dynet] internal.NewClass) {
+```
+
+* write tests
 
 ## Running the Examples
 

--- a/contrib/swig/src/main/scala/edu/cmu/dynet/Expression.scala
+++ b/contrib/swig/src/main/scala/edu/cmu/dynet/Expression.scala
@@ -235,5 +235,13 @@ object Expression {
   def inverse(x: Expression): Expression = unary(x, dn.inverse)
   def logdet(x: Expression): Expression = unary(x, dn.logdet)
   def traceOfProduct(x: Expression, y: Expression): Expression = binary(x, y, dn.trace_of_product)
+
+  /** Augment numbers so that they can do arithmetic with expressions. */
+  implicit class ImplicitNumerics[T](x: T)(implicit n: Numeric[T]) {
+    import n._
+    def +(e: Expression): Expression = Expression.exprPlus(x.toFloat, e)
+    def *(e: Expression): Expression = Expression.exprTimes(x.toFloat, e)
+    def -(e: Expression): Expression = Expression.exprMinus(x.toFloat, e)
+  }
 }
 

--- a/contrib/swig/src/main/scala/edu/cmu/dynet/Parameter.scala
+++ b/contrib/swig/src/main/scala/edu/cmu/dynet/Parameter.scala
@@ -13,10 +13,11 @@ class LookupParameterStorage private[dynet](private[dynet] val storage: internal
   def size(): Long = storage.size()
 }
 
-/** A (learnable) parameter of a model. You don't construct it directly, but through e.g.
-  * [[edu.cmu.dynet.Model.addParameters()]].
+/** A (learnable) parameter of a model.
   */
 class Parameter private[dynet] (private[dynet] val parameter: internal.Parameter) {
+  def this(model: Model, index: Long) { this(new internal.Parameter(model.model, index)) }
+
   def zero(): Unit = parameter.zero()
 
   def dim(): Dim = new Dim(parameter.dim)
@@ -27,6 +28,9 @@ class Parameter private[dynet] (private[dynet] val parameter: internal.Parameter
 }
 
 class LookupParameter private[dynet] (private[dynet] val lookupParameter: internal.LookupParameter) {
+
+  def this(model: Model, index: Long) { this(new internal.LookupParameter(model.model, index))}
+
   def initialize(index: Long, values: FloatVector) = {
     lookupParameter.initialize(index, values.vector)
   }

--- a/contrib/swig/src/main/scala/edu/cmu/dynet/Tensor.scala
+++ b/contrib/swig/src/main/scala/edu/cmu/dynet/Tensor.scala
@@ -7,5 +7,6 @@ class Tensor private[dynet] (private[dynet] val tensor: internal.Tensor) {
   def toFloat(): Float = internal.dynet_swig.as_scalar(tensor)
   def toVector(): FloatVector = new FloatVector(internal.dynet_swig.as_vector(tensor))
   def toSeq(): Seq[Float] = toVector()
+  def getD(): Dim = new Dim(tensor.getD)
 }
 

--- a/contrib/swig/src/main/scala/edu/cmu/dynet/Utilities.scala
+++ b/contrib/swig/src/main/scala/edu/cmu/dynet/Utilities.scala
@@ -29,7 +29,7 @@ object Utilities {
   }
 
   /** Augment numbers so that they can do arithmetic with expressions. */
-  implicit class RichNumeric[T](x: T)(implicit n: Numeric[T]) {
+  implicit class NumbersAsExpressions[T](x: T)(implicit n: Numeric[T]) {
     import n._
     def +(e: Expression): Expression = Expression.exprPlus(x.toFloat, e)
     def *(e: Expression): Expression = Expression.exprTimes(x.toFloat, e)

--- a/contrib/swig/src/main/scala/edu/cmu/dynet/Utilities.scala
+++ b/contrib/swig/src/main/scala/edu/cmu/dynet/Utilities.scala
@@ -27,12 +27,4 @@ object Utilities {
         .last
         ._2
   }
-
-  /** Augment numbers so that they can do arithmetic with expressions. */
-  implicit class NumbersAsExpressions[T](x: T)(implicit n: Numeric[T]) {
-    import n._
-    def +(e: Expression): Expression = Expression.exprPlus(x.toFloat, e)
-    def *(e: Expression): Expression = Expression.exprTimes(x.toFloat, e)
-    def -(e: Expression): Expression = Expression.exprMinus(x.toFloat, e)
-  }
 }


### PR DESCRIPTION
just a couple of missing bindings, and I renamed `RichNumeric` to `NumbersAsExpressions`, which is more descriptive (since in the new API people will probably import it explicitly)